### PR TITLE
Initial commit to include directed degree measures in the network class

### DIFF
--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -155,6 +155,13 @@ Node-weighted network measures / node-splitting invariance
     `doi:10.1209/0295-5075/102/28007
     <http://dx.doi.org/10.1209/0295-5075/102/28007>`__
 
+.. [Zemp2014] D.C. Zemp,  M. Wiedermann, J. Kurths, A. Rammig, J.F. Donges.
+    "Node-weighted measures for complex networks with directed and weighted
+    edges for studying continental moisture recycling".
+    In *Europhysics Letters*, vol. 107.5, p58005 (2014)
+    `doi:10.1209/0295-5075/107/58005
+    <http://dx.doi.org/10.1209/0295-5075/107/58005>`__
+
 Climate data analysis (general)
 ===============================
 [Bretherton1992]_.

--- a/pylintrc
+++ b/pylintrc
@@ -210,7 +210,7 @@ no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 # max-module-lines=1000
-max-module-lines=5800
+max-module-lines=6000
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/pylintrc
+++ b/pylintrc
@@ -210,7 +210,7 @@ no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 # max-module-lines=1000
-max-module-lines=5600
+max-module-lines=5800
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).
@@ -373,7 +373,7 @@ min-public-methods=2
 
 # Maximum number of public methods for a class (see R0904).
 # max-public-methods=20
-max-public-methods=110
+max-public-methods=120
 
 
 [CLASSES]

--- a/pyunicorn/core/network.py
+++ b/pyunicorn/core/network.py
@@ -2149,7 +2149,7 @@ can only take values <<in>> or <<out>>."
 
         **Example:**
 
-        >>> Network.SmallDirectedTestNetwork().local_cyclemotif_clustering()
+        >>> r(Network.SmallDirectedTestNetwork().local_cyclemotif_clustering())
         Calculating local cycle motif clustering coefficient...
         array([ 0.25,  0.25,  0.  ,  0.  ,  0.5 ,  0.  ])
 
@@ -2172,7 +2172,7 @@ can only take values <<in>> or <<out>>."
 
         **Example:**
 
-        >>> Network.SmallDirectedTestNetwork().local_midmotif_clustering()
+        >>> r(Network.SmallDirectedTestNetwork().local_midmotif_clustering())
         Calculating local mid. motif clustering coefficient...
         array([ 0. ,  0. ,  0. ,  1. ,  0.5,  0. ])
 
@@ -2195,7 +2195,7 @@ can only take values <<in>> or <<out>>."
 
         **Example:**
 
-        >>> Network.SmallDirectedTestNetwork().local_inmotif_clustering()
+        >>> r(Network.SmallDirectedTestNetwork().local_inmotif_clustering())
         Calculating local in motif clustering coefficient...
         array([ 0. ,  0.5,  0.5,  0. ,  0. ,  0. ])
 
@@ -2218,7 +2218,7 @@ can only take values <<in>> or <<out>>."
 
         **Example:**
 
-        >>> Network.SmallDirectedTestNetwork().local_outmotif_clustering()
+        >>> r(Network.SmallDirectedTestNetwork().local_outmotif_clustering())
         Calculating local out motif clustering coefficient...
         array([ 0.5,  0.5,  0. ,  0. ,  0. ,  0. ])
 
@@ -2245,25 +2245,22 @@ can only take values <<in>> or <<out>>."
         **Examples:**
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.nsi_local_cyclemotif_clustering()
+        >>> r(net.nsi_local_cyclemotif_clustering())
         Calculating local nsi cycle motif clustering coefficient...
-        array([ 0.18448637,  0.20275024,  0.3220339 ,  0.32236842,  0.34385965,
-                0.625     ])
-        >>> net.splitted_copy(node=1).nsi_local_cyclemotif_clustering()
+        array([ 0.1845,  0.2028,  0.322 ,  0.3224,  0.3439,  0.625 ])
+        >>> r(net.splitted_copy(node=1).nsi_local_cyclemotif_clustering())
         Calculating local nsi cycle motif clustering coefficient...
-        array([ 0.18448637,  0.20275024,  0.3220339 ,  0.32236842,  0.34385965,
-                0.625     ,  0.20275024])
+        array([ 0.1845,  0.2028,  0.322 ,  0.3224,  0.3439,  0.625 ,  0.2028])
 
         as compared to the unweighted version:
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.local_cyclemotif_clustering()
+        >>> r(net.local_cyclemotif_clustering())
         Calculating local cycle motif clustering coefficient...
         array([ 0.25,  0.25,  0.  ,  0.  ,  0.5 ,  0.  ])
-        >>> net.splitted_copy(node=1).local_cyclemotif_clustering()
+        >>> r(net.splitted_copy(node=1).local_cyclemotif_clustering())
         Calculating local cycle motif clustering coefficient...
-        array([ 0.33333333,  0.125     ,  0.        ,  0.        ,  0.5       ,
-                0.        ,  0.125     ])
+        array([ 0.3333,  0.125 ,  0.    ,  0.    ,  0.5   ,  0.    ,  0.125 ])
 
         :arg str key: link attribute key (optional)
         """
@@ -2287,22 +2284,20 @@ can only take values <<in>> or <<out>>."
         **Examples:**
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.nsi_local_midmotif_clustering()
+        >>> r(net.nsi_local_midmotif_clustering())
         Calculating local nsi mid. motif clustering coefficient...
-        array([ 0.45372866,  0.51646946,  1.        ,  1.        ,  0.88815789,
-                1.        ])
-        >>> net.splitted_copy(node=4).nsi_local_midmotif_clustering()
+        array([ 0.4537,  0.5165,  1.    ,  1.    ,  0.8882,  1.    ])
+        >>> r(net.splitted_copy(node=4).nsi_local_midmotif_clustering())
         Calculating local nsi mid. motif clustering coefficient...
-        array([ 0.45372866,  0.51646946,  1.        ,  1.        ,  0.88815789,
-                1.        ,  0.88815789])
+        array([ 0.4537,  0.5165,  1.    ,  1.    ,  0.8882,  1.    ,  0.8882])
 
         as compared to the unweighted version:
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.local_midmotif_clustering()
+        >>> r(net.local_midmotif_clustering())
         Calculating local mid. motif clustering coefficient...
         array([ 0. ,  0. ,  0. ,  1. ,  0.5,  0. ])
-        >>> net.splitted_copy(node=4).local_midmotif_clustering()
+        >>> r(net.splitted_copy(node=4).local_midmotif_clustering())
         Calculating local mid. motif clustering coefficient...
         array([ 0. ,  0. ,  0. ,  1. ,  0.8,  0. ,  0.8])
 
@@ -2328,25 +2323,23 @@ can only take values <<in>> or <<out>>."
         **Examples:**
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.nsi_local_inmotif_clustering()
+        >>> r(net.nsi_local_inmotif_clustering())
         Calculating local nsi in motif clustering coefficient...
-        array([ 0.52884858,  0.66998932,  0.66934789,  0.75694444,  0.755625  ,
-                1.        ])
-        >>> net.splitted_copy(node=1).nsi_local_inmotif_clustering()
+        array([ 0.5288,  0.67  ,  0.6693,  0.7569,  0.7556,  1.    ])
+        >>> r(net.splitted_copy(node=1).nsi_local_inmotif_clustering())
         Calculating local nsi in motif clustering coefficient...
-        array([ 0.52884858,  0.66998932,  0.66934789,  0.75694444,  0.755625  ,
-                1.        ,  0.66998932])
+        array([ 0.5288,  0.67  ,  0.6693,  0.7569,  0.7556,  1.    ,  0.67  ])
 
         as compared to the unweighted version:
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.local_inmotif_clustering()
+        >>> r(net.local_inmotif_clustering())
         Calculating local in motif clustering coefficient...
         array([ 0. ,  0.5,  0.5,  0. ,  0. ,  0. ])
-        >>> net.splitted_copy(node=1).local_inmotif_clustering()
+        >>> r(net.splitted_copy(node=1).local_inmotif_clustering())
         Calculating local in motif clustering coefficient...
-        array([ 0.        ,  0.5       ,  0.66666667,  0.        ,  1.        ,
-                0.        ,  0.5       ])
+        array([ 0.    ,  0.5   ,  0.6667,  0.    ,  1.    ,  0.    ,  0.5   ])
+
 
         :arg str key: link attribute key (optional)
         """
@@ -2370,25 +2363,22 @@ can only take values <<in>> or <<out>>."
         **Examples:**
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.nsi_local_outmotif_clustering()
+        >>> r(net.nsi_local_outmotif_clustering())
         Calculating local nsi out motif clustering coefficient...
-        array([ 0.66998932,  0.66934789,  1.        ,  0.75277008,  0.58387196,
-                0.765625  ])
-        >>> net.splitted_copy(node=0).nsi_local_outmotif_clustering()
+        array([ 0.67  ,  0.6693,  1.    ,  0.7528,  0.5839,  0.7656])
+        >>> r(net.splitted_copy(node=0).nsi_local_outmotif_clustering())
         Calculating local nsi out motif clustering coefficient...
-        array([ 0.66998932,  0.66934789,  1.        ,  0.75277008,  0.58387196,
-                0.765625  ,  0.66998932])
+        array([ 0.67  ,  0.6693,  1.    ,  0.7528,  0.5839,  0.7656,  0.67  ])
 
         as compared to the unweighted version:
 
         >>> net = Network.SmallDirectedTestNetwork()
-        >>> net.local_outmotif_clustering()
+        >>> r(net.local_outmotif_clustering())
         Calculating local out motif clustering coefficient...
         array([ 0.5,  0.5,  0. ,  0. ,  0. ,  0. ])
-        >>> net.splitted_copy(node=0).local_outmotif_clustering()
+        >>> r(net.splitted_copy(node=0).local_outmotif_clustering())
         Calculating local out motif clustering coefficient...
-        array([ 0.5       ,  0.5       ,  0.        ,  0.        ,  0.33333333,
-                1.        ,  0.5       ])
+        array([ 0.5   ,  0.5   ,  0.    ,  0.    ,  0.3333,  1.    ,  0.5   ])
 
         :arg str key: link attribute key (optional)
         """

--- a/pyunicorn/core/network.py
+++ b/pyunicorn/core/network.py
@@ -1604,7 +1604,7 @@ can only take values <<in>> or <<out>>."
         :rtype: array([float])
         """
         if self.directed:
-            return None  # TODO: generate error message
+            return self.nsi_indegree() + self.nsi_outdegree()
         else:
             return self.sp_Aplus() * self.node_weights
 
@@ -1656,6 +1656,50 @@ can only take values <<in>> or <<out>>."
             return self.nsi_degree_uncorr()
         else:
             return self.nsi_degree_uncorr()/typical_weight - 1.0
+
+    def nsi_indegree(self):
+        """
+        For each node, return its n.s.i. indegree
+
+        **Examples:**
+
+        >>> net = Network.SmallTestNetwork()
+        >>> net.nsi_indegree()
+        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ])
+        >>> net.splitted_copy().nsi_indegree()
+        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ,  4. ])
+
+        as compared to the unweighted version:
+
+        >>> net = Network.SmallTestNetwork()
+        >>> net.indegree()
+        array([3, 3, 2, 2, 3, 1])
+        >>> net.splitted_copy().indegree()
+        array([4, 3, 2, 2, 3, 2, 2])
+        """
+        return self.node_weights * self.sp_Aplus()
+
+    def nsi_outdegree(self):
+        """
+        For each node, return its n.s.i.outdegree
+
+        **Examples:**
+
+        >>> net = Network.SmallTestNetwork()
+        >>> net.nsi_outdegree()
+        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ])
+        >>> net.splitted_copy().nsi_outdegree()
+        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ,  4. ])
+
+        as compared to the unweighted version:
+
+        >>> net = Network.SmallTestNetwork()
+        >>> net.outdegree()
+        array([3, 3, 2, 2, 3, 1])
+        >>> net.splitted_copy().outdegree()
+        array([4, 3, 2, 2, 3, 2, 2])
+        """
+        return self.sp_Aplus() * self.node_weights
 
     @cached_const('base', 'degree df', 'the degree frequency distribution')
     def degree_distribution(self):

--- a/pyunicorn/core/network.py
+++ b/pyunicorn/core/network.py
@@ -2031,6 +2031,24 @@ can only take values <<in>> or <<out>>."
         """
         return self.local_clustering().mean()
 
+    def _motif_clustering_helper(self, t_func, T):
+        """
+        Helper function to compute the local motif clustering coefficients.
+        For each node, returns a specific clustering coefficient, depending
+        on the input arguments.
+
+        :arg function t_func: multiplication of adjacency-type matrices
+        :arg 1d numpy array [node]: denominator made out of (in/out/bil)degrees
+        :rtype: 1d numpy array [node] of floats between 0 and 1
+        """
+        A = self.sp_A
+        t = t_func(A).diagonal()
+        T = T.astype(float)
+        T[T == 0] = np.nan
+        C = t / T
+        C[np.isnan(C)] = 0
+        return C
+
     @cached_const('base', 'local cyclemotiv',
                   'local cycle motif clustering coefficient')
     def local_cyclemotif_clustering(self):
@@ -2044,14 +2062,10 @@ can only take values <<in>> or <<out>>."
 
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
-        A = self.sp_A
-        t = (A * A * A).diagonal()
+        def t_func(x):
+            return x * x * x
         T = self.indegree() * self.outdegree() - self.bildegree()
-        T = T.astype(float)
-        T[T == 0] = np.nan
-        C = t / T
-        C[np.isnan(C)] = 0
-        return C
+        return self._motif_clustering_helper(t_func, T)
 
     @cached_const('base', 'local midmotiv',
                   'local mid. motif clustering coefficient')
@@ -2066,14 +2080,10 @@ can only take values <<in>> or <<out>>."
 
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
-        A = self.sp_A
-        t = (A * A.T * A).diagonal()
+        def t_func(x):
+            return x * x.T * x
         T = self.indegree() * self.outdegree() - self.bildegree()
-        T = T.astype(float)
-        T[T == 0] = np.nan
-        C = t / T
-        C[np.isnan(C)] = 0
-        return C
+        return self._motif_clustering_helper(t_func, T)
 
     @cached_const('base', 'local inmotiv',
                   'local in motif clustering coefficient')
@@ -2088,14 +2098,10 @@ can only take values <<in>> or <<out>>."
 
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
-        A = self.sp_A
-        t = (A.T * A * A).diagonal()
+        def t_func(x):
+            return x.T * x * x
         T = self.indegree() * (self.indegree() - 1)
-        T = T.astype(float)
-        T[T == 0] = np.nan
-        C = t / T
-        C[np.isnan(C)] = 0
-        return C
+        return self._motif_clustering_helper(t_func, T)
 
     @cached_const('base', 'local outmotiv',
                   'local out motif clustering coefficient')
@@ -2110,14 +2116,10 @@ can only take values <<in>> or <<out>>."
 
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
-        A = self.sp_A
-        t = (A * A * A.T).diagonal()
+        def t_func(x):
+            return x * x * x.T
         T = self.outdegree() * (self.outdegree() - 1)
-        T = T.astype(float)
-        T[T == 0] = np.nan
-        C = t / T
-        C[np.isnan(C)] = 0
-        return C
+        return self._motif_clustering_helper(t_func, T)
 
     @cached_const('base', 'transitivity', 'transitivity coefficient (C_1)')
     def transitivity(self):

--- a/pyunicorn/core/network.py
+++ b/pyunicorn/core/network.py
@@ -675,6 +675,30 @@ class Network(object):
                        silence_level=1)
 
     @staticmethod
+    def SmallDirectedTestNetwork():
+        """
+        Return a 6-node directed test network with node and edge weights.
+
+        The node weights are [1.5, 1.7, 1.9, 2.1, 2.3, 2.5],
+        a typical node weight for corrected n.s.i. measures would be 2.0.
+
+        :rtype: Network instance
+        """
+        nw = Network(adjacency=[[0, 1, 0, 1, 0, 0], [0, 0, 1, 0, 1, 0],
+                                [0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0],
+                                [1, 0, 1, 0, 0, 0], [1, 0, 0, 0, 0, 0]],
+                     directed=True,
+                     node_weights=[1.5, 1.7, 1.9, 2.1, 2.3, 2.5],
+                     silence_level=1)
+        nw.set_link_attribute("link_weights", np.array([[0, 1.3, 0, 2.5, 0, 0],
+                                                        [0, 0, 1.9, 0, 1.0, 0],
+                                                        [0, 0, 0, 0, 0, 0],
+                                                        [0, 3.0, 0, 0, 0, 0],
+                                                        [2.1, 0, 2.7, 0, 0, 0],
+                                                        [1.5, 0, 0, 0, 0, 0]]))
+        return nw
+
+    @staticmethod
     def ErdosRenyi(n_nodes=100, link_probability=None, n_links=None,
                    silence_level=0):
         """
@@ -1568,8 +1592,8 @@ can only take values <<in>> or <<out>>."
 
         **Example:**
 
-        >>> Network.SmallTestNetwork().indegree()
-        array([3, 3, 2, 2, 3, 1])
+        >>> Network.SmallDirectedTestNetwork().indegree()
+        array([2, 2, 2, 1, 1, 0])
 
         :rtype: array([int>=0])
         """
@@ -1582,8 +1606,8 @@ can only take values <<in>> or <<out>>."
 
         **Example:**
 
-        >>> Network.SmallTestNetwork().outdegree()
-        array([3, 3, 2, 2, 3, 1])
+        >>> Network.SmallDirectedTestNetwork().outdegree()
+        array([2, 2, 0, 1, 2, 1])
 
         :rtype: array([int>=0])
         """
@@ -1656,19 +1680,19 @@ can only take values <<in>> or <<out>>."
 
         **Examples:**
 
-        >>> net = Network.SmallTestNetwork()
+        >>> net = Network.SmallDirectedTestNetwork()
         >>> net.nsi_indegree()
-        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ])
+        array([ 6.3,  5.3,  5.9,  3.6,  4. ,  2.5])
         >>> net.splitted_copy().nsi_indegree()
-        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ,  4. ])
+        array([ 6.3,  5.3,  5.9,  3.6,  4. ,  2.5,  2.5])
 
         as compared to the unweighted version:
 
-        >>> net = Network.SmallTestNetwork()
+        >>> net = Network.SmallDirectedTestNetwork()
         >>> net.indegree()
-        array([3, 3, 2, 2, 3, 1])
+        array([2, 2, 2, 1, 1, 0])
         >>> net.splitted_copy().indegree()
-        array([4, 3, 2, 2, 3, 2, 2])
+        array([3, 2, 2, 1, 1, 1, 1])
         """
         return self.node_weights * self.sp_Aplus()
 
@@ -1678,19 +1702,19 @@ can only take values <<in>> or <<out>>."
 
         **Examples:**
 
-        >>> net = Network.SmallTestNetwork()
+        >>> net = Network.SmallDirectedTestNetwork()
         >>> net.nsi_outdegree()
-        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ])
+        array([ 5.3,  5.9,  1.9,  3.8,  5.7,  4. ])
         >>> net.splitted_copy().nsi_outdegree()
-        array([ 8.4,  8. ,  5.9,  5.3,  7.4,  4. ,  4. ])
+        array([ 5.3,  5.9,  1.9,  3.8,  5.7,  4. ,  4. ])
 
         as compared to the unweighted version:
 
-        >>> net = Network.SmallTestNetwork()
+        >>> net = Network.SmallDirectedTestNetwork()
         >>> net.outdegree()
-        array([3, 3, 2, 2, 3, 1])
+        array([2, 2, 0, 1, 2, 1])
         >>> net.splitted_copy().outdegree()
-        array([4, 3, 2, 2, 3, 2, 2])
+        array([2, 2, 0, 1, 2, 2, 2])
         """
         return self.sp_Aplus() * self.node_weights
 

--- a/pyunicorn/core/network.py
+++ b/pyunicorn/core/network.py
@@ -62,6 +62,9 @@ def cache_helper(self, cat, key, msg, func, *args, **kwargs):
     :arg str msg: message to be displayed during first calculation
     :arg func func: function to be cached
     """
+    # categories can be added on the fly?!?!
+    self.cache.setdefault(cat, {})
+
     if self.cache[cat].setdefault(key) is None:
         if msg is not None and self.silence_level <= 1:
             print 'Calculating ' + msg + '...'
@@ -367,8 +370,21 @@ class Network(object):
         new_w[N] = proportion * w[node]
         new_w[node] = (1.0 - proportion) * w[node]
 
-        return Network(adjacency=new_A, directed=self.directed,
-                       node_weights=new_w, silence_level=self.silence_level)
+        new_NW = Network(adjacency=new_A, directed=self.directed,
+                         node_weights=new_w, silence_level=self.silence_level)
+        # -- Copy link attributes
+        for a in self.graph.es.attributes():
+            W = self.link_attribute(a)
+            new_W = np.zeros((N+1, N+1))
+            new_W[:N, :N] = W
+            # add last row and column
+            new_W[:N, N] = W[:, node]
+            new_W[N, :N] = W[node, :]
+            # assign weight between new node and original and for self loop
+            new_W[node, N] = new_W[N, node] = new_W[N, N] = W[node, node]
+            new_NW.set_link_attribute(a, new_W)
+        # --
+        return new_NW
 
     @property
     def adjacency(self):
@@ -667,12 +683,20 @@ class Network(object):
 
         :rtype: Network instance
         """
-        return Network(adjacency=[[0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 1, 0],
-                                  [0, 1, 0, 0, 1, 0], [1, 1, 0, 0, 0, 0],
-                                  [1, 1, 1, 0, 0, 0], [1, 0, 0, 0, 0, 0]],
-                       directed=False,
-                       node_weights=[1.5, 1.7, 1.9, 2.1, 2.3, 2.5],
-                       silence_level=1)
+        nw = Network(adjacency=[[0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 1, 0],
+                                [0, 1, 0, 0, 1, 0], [1, 1, 0, 0, 0, 0],
+                                [1, 1, 1, 0, 0, 0], [1, 0, 0, 0, 0, 0]],
+                     directed=False,
+                     node_weights=[1.5, 1.7, 1.9, 2.1, 2.3, 2.5],
+                     silence_level=1)
+        link_weights = np.array([[0, 0, 0, 1.3, 2.5, 1.1],
+                                 [0, 0, 2.3, 2.9, 2.7, 0],
+                                 [0, 2.3, 0, 0, 1.5, 0],
+                                 [1.3, 2.9, 0, 0, 0, 0],
+                                 [2.5, 2.7, 1.5, 0, 0, 0],
+                                 [1.1, 0, 0, 0, 0, 0]])
+        nw.set_link_attribute("link_weights", link_weights)
+        return nw
 
     @staticmethod
     def SmallDirectedTestNetwork():
@@ -1567,57 +1591,77 @@ can only take values <<in>> or <<out>>."
     #  Degree related measures
     #
 
-    @cached_const('base', 'degree')
-    def degree(self):
+    # @cached_const('base', 'degree')
+    @cached_var('degree')
+    def degree(self, key=None):
         """
         Return list of degrees.
+
+        If a link attribute key is specified, return the associated strength
 
         **Example:**
 
         >>> Network.SmallTestNetwork().degree()
         array([3, 3, 2, 2, 3, 1])
 
+        :arg str key: link attribute key [optional]
         :rtype: array([int>=0])
         """
         if self.directed:
-            return self.indegree() + self.outdegree()
+            return self.indegree(key) + self.outdegree(key)
         else:
-            return self.outdegree()
+            return self.outdegree(key)
 
     # TODO: use directed example here and elsewhere
-    @cached_const('base', 'indegree')
-    def indegree(self):
+    @cached_var('indegree')
+    def indegree(self, key=None):
         """
         Return list of in-degrees.
+
+        If a link attribute key is specified, return the associated in strength
 
         **Example:**
 
         >>> Network.SmallDirectedTestNetwork().indegree()
         array([2, 2, 2, 1, 1, 0])
 
+        :arg str key: link attribute key [optional]
         :rtype: array([int>=0])
         """
-        return self.sp_A.sum(axis=0).A.squeeze().astype(int)
+        if key is None:
+            return self.sp_A.sum(axis=0).A.squeeze().astype(int)
+        else:
+            return self.link_attribute(key).sum(axis=0).T
 
-    @cached_const('base', 'outdegree')
-    def outdegree(self):
+    @cached_var('outdegree')
+    def outdegree(self, key=None):
         """
         Return list of out-degrees.
+
+        If a link attribute key is specified, return the associated out
+        strength
 
         **Example:**
 
         >>> Network.SmallDirectedTestNetwork().outdegree()
         array([2, 2, 0, 1, 2, 1])
 
+        :arg str key: link attribute key [optional]
         :rtype: array([int>=0])
         """
-        return self.sp_A.sum(axis=1).T.A.squeeze().astype(int)
+        if key is None:
+            return self.sp_A.sum(axis=1).T.A.squeeze().astype(int)
+        else:
+            return self.link_attribute(key).sum(axis=1).T
 
-    @cached_const('base', 'bildegree')
-    def bildegree(self):
+    @cached_var('bildegree')
+    def bildegree(self, key=None):
         """
-        Return list of bilateral degrees, i.e. the number of in- and out-going
-        edges.
+        Return list of bilateral degrees, i.e. the number of simultaneously in-
+        and out-going edges.
+
+        If a link attribute key is specified, return the associated bilateral
+        strength
 
         **Exmaple:**
 
@@ -1627,19 +1671,31 @@ can only take values <<in>> or <<out>>."
         >>> (net.bildegree() == net.degree()).all()
         True
         """
-        return (self.sp_A * self.sp_A).diagonal()
+        if key is None:
+            return (self.sp_A * self.sp_A).diagonal()
+        else:
+            w = np.matrix(self.link_attribute(key))
+            return (w * w).diagonal()
 
-    @cached_const('nsi', 'degree', 'n.s.i. degree')
-    def nsi_degree_uncorr(self):
+    @cached_var('nsi_degree', 'n.s.i. degree')
+    def nsi_degree_uncorr(self, key=None):
         """
         For each node, return its uncorrected n.s.i. degree.
 
+        If a link attribute key is specified, return the associated nsi
+        strength
+
+        :arg str key: link attribute key [optional]
         :rtype: array([float])
         """
         if self.directed:
-            return self.nsi_indegree() + self.nsi_outdegree()
+            return self.nsi_indegree(key) + self.nsi_outdegree(key)
         else:
-            return self.sp_Aplus() * self.node_weights
+            if key is None:
+                return self.sp_Aplus() * self.node_weights
+            else:
+                w = np.matrix(self.link_attribute(key))
+                return (self.node_weights * w).A.squeeze()
 
     def sp_nsi_diag_k(self):
         """Sparse diagonal matrix of n.s.i. degrees"""
@@ -1651,9 +1707,13 @@ can only take values <<in>> or <<out>>."
         return sp.diags([np.power(self.nsi_degree_uncorr(), -1)], [0],
                         shape=(self.N, self.N), format='csc')
 
-    def nsi_degree(self, typical_weight=None):
+    def nsi_degree(self, typical_weight=None, key=None):
         """
         For each node, return its uncorrected or corrected n.s.i. degree.
+
+        If a link attribute key is specified, return the associated nsi
+        strength
+
 
         **Examples:**
 
@@ -1682,18 +1742,21 @@ can only take values <<in>> or <<out>>."
         :arg  typical_weight: Optional typical node weight to be used for
                               correction. If None, the uncorrected measure is
                               returned. (Default: None)
-
+        :arg str key: link attribute key (optional)
         :rtype: array([float])
         """
         if typical_weight is None:
-            return self.nsi_degree_uncorr()
+            return self.nsi_degree_uncorr(key)
         else:
-            return self.nsi_degree_uncorr()/typical_weight - 1.0
+            return self.nsi_degree_uncorr(key)/typical_weight - 1.0
 
-    @cached_const('nsi', 'indegree')
-    def nsi_indegree(self):
+    @cached_var('nsi_indegree')
+    def nsi_indegree(self, key=None):
         """
         For each node, return its n.s.i. indegree
+
+        If a link attribute key is specified, return the associated nsi in
+        strength
 
         **Examples:**
 
@@ -1710,13 +1773,22 @@ can only take values <<in>> or <<out>>."
         array([2, 2, 2, 1, 1, 0])
         >>> net.splitted_copy().indegree()
         array([3, 2, 2, 1, 1, 1, 1])
-        """
-        return self.node_weights * self.sp_Aplus()
 
-    @cached_const('nsi', 'outdegree')
-    def nsi_outdegree(self):
+        :arg str key: link attribute key [optional]
+        """
+        if key is None:
+            return self.node_weights * self.sp_Aplus()
+        else:
+            w = np.matrix(self.link_attribute(key))
+            return (np.matrix(self.node_weights) * w).A.squeeze()
+
+    @cached_var('nsi_outdegree')
+    def nsi_outdegree(self, key=None):
         """
         For each node, return its n.s.i.outdegree
+
+        If a link attribute key is specified, return the associated nsi out
+        strength
 
         **Examples:**
 
@@ -1733,8 +1805,14 @@ can only take values <<in>> or <<out>>."
         array([2, 2, 0, 1, 2, 1])
         >>> net.splitted_copy().outdegree()
         array([2, 2, 0, 1, 2, 2, 2])
+
+        :arg str key: link attribute key [optional]
         """
-        return self.sp_Aplus() * self.node_weights
+        if key is None:
+            return self.sp_Aplus() * self.node_weights
+        else:
+            w = np.matrix(self.link_attribute(key))
+            return (w * np.matrix(self.node_weights).T).T.A.squeeze()
 
     @cached_const('base', 'degree df', 'the degree frequency distribution')
     def degree_distribution(self):
@@ -2031,7 +2109,7 @@ can only take values <<in>> or <<out>>."
         """
         return self.local_clustering().mean()
 
-    def _motif_clustering_helper(self, t_func, T, nsi=False):
+    def _motif_clustering_helper(self, t_func, T, key=None, nsi=False):
         """
         Helper function to compute the local motif clustering coefficients.
         For each node, returns a specific clustering coefficient, depending
@@ -2039,16 +2117,20 @@ can only take values <<in>> or <<out>>."
 
         :arg function t_func: multiplication of adjacency-type matrices
         :arg 1d numpy array [node]: denominator made out of (in/out/bil)degrees
+        :arg str key: link attribute key (optional)
+        :arg bool nsi: flag for nsi calculation (default: False)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
         if nsi:
-            A = self.sp_Aplus() * sp.csc_matrix(np.eye(self.N) *
-                                                self.node_weights)
-            AT = self.sp_Aplus().T * sp.csc_matrix(np.eye(self.N) *
-                                                   self.node_weights)
+            nodew = sp.csc_matrix(np.eye(self.N) * self.node_weights)
+        if key is None:
+            A = self.sp_Aplus() * nodew if nsi else self.sp_A
+            AT = self.sp_Aplus().T * nodew if nsi else A.T
         else:
-            A = self.sp_A
-            AT = A.T
+            M = sp.csc_matrix(self.link_attribute(key)**(1/3.))
+            A = M * nodew if nsi else M
+            AT = M.T * nodew if nsi else M.T
+
         t = t_func(A, AT).diagonal()
         T = T.astype(float)
         T[T == 0] = np.nan
@@ -2056,12 +2138,14 @@ can only take values <<in>> or <<out>>."
         C[np.isnan(C)] = 0
         return C
 
-    @cached_const('base', 'local cyclemotif',
-                  'local cycle motif clustering coefficient')
-    def local_cyclemotif_clustering(self):
+    @cached_var('local cyclemotif', 'local cycle motif clustering coefficient')
+    def local_cyclemotif_clustering(self, key=None):
         """
         For each node, return the clustering coefficient with respect to the
         cycle motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
 
         **Example:**
 
@@ -2069,19 +2153,22 @@ can only take values <<in>> or <<out>>."
         Calculating local cycle motif clustering coefficient...
         array([ 0.25,  0.25,  0.  ,  0.  ,  0.5 ,  0.  ])
 
+        :arg str key: link attribute key (optional)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
         def t_func(x, xT):
             return x * x * x
         T = self.indegree() * self.outdegree() - self.bildegree()
-        return self._motif_clustering_helper(t_func, T)
+        return self._motif_clustering_helper(t_func, T, key=key)
 
-    @cached_const('base', 'local midmotif',
-                  'local mid. motif clustering coefficient')
-    def local_midmotif_clustering(self):
+    @cached_var('local midmotif', 'local mid. motif clustering coefficient')
+    def local_midmotif_clustering(self, key=None):
         """
         For each node, return the clustering coefficient with respect to the
         mid. motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
 
         **Example:**
 
@@ -2089,19 +2176,22 @@ can only take values <<in>> or <<out>>."
         Calculating local mid. motif clustering coefficient...
         array([ 0. ,  0. ,  0. ,  1. ,  0.5,  0. ])
 
+        :arg str key: link attribute key (optional)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
         def t_func(x, xT):
             return x * xT * x
         T = self.indegree() * self.outdegree() - self.bildegree()
-        return self._motif_clustering_helper(t_func, T)
+        return self._motif_clustering_helper(t_func, T, key=key)
 
-    @cached_const('base', 'local inmotif',
-                  'local in motif clustering coefficient')
-    def local_inmotif_clustering(self):
+    @cached_var('local inmotif', 'local in motif clustering coefficient')
+    def local_inmotif_clustering(self, key=None):
         """
         For each node, return the clustering coefficient with respect to the
         in motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
 
         **Example:**
 
@@ -2109,19 +2199,22 @@ can only take values <<in>> or <<out>>."
         Calculating local in motif clustering coefficient...
         array([ 0. ,  0.5,  0.5,  0. ,  0. ,  0. ])
 
+        :arg str key: link attribute key (optional)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
         def t_func(x, xT):
             return xT * x * x
         T = self.indegree() * (self.indegree() - 1)
-        return self._motif_clustering_helper(t_func, T)
+        return self._motif_clustering_helper(t_func, T, key=key)
 
-    @cached_const('base', 'local outmotif',
-                  'local out motif clustering coefficient')
-    def local_outmotif_clustering(self):
+    @cached_var('local outmotif', 'local out motif clustering coefficient')
+    def local_outmotif_clustering(self, key=None):
         """
         For each node, return the clustering coefficient with respect to the
         out motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
 
         **Example:**
 
@@ -2129,19 +2222,25 @@ can only take values <<in>> or <<out>>."
         Calculating local out motif clustering coefficient...
         array([ 0.5,  0.5,  0. ,  0. ,  0. ,  0. ])
 
+        :arg str key: link attribute key (optional)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
         def t_func(x, xT):
             return x * x * xT
         T = self.outdegree() * (self.outdegree() - 1)
-        return self._motif_clustering_helper(t_func, T)
+        return self._motif_clustering_helper(t_func, T, key=key)
 
-    @cached_const('nsi', 'local cyclemotif',
-                  'local nsi cycle motif clustering coefficient')
-    def nsi_local_cyclemotif_clustering(self):
+    @cached_var('nsi local cyclemotif',
+                'local nsi cycle motif clustering coefficient')
+    def nsi_local_cyclemotif_clustering(self, key=None):
         """
         For each node, return the nsi clustering coefficient with respect to
         the cycle motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
+
+        Reference: [Zemp2014]_
 
         **Examples:**
 
@@ -2165,18 +2264,25 @@ can only take values <<in>> or <<out>>."
         Calculating local cycle motif clustering coefficient...
         array([ 0.33333333,  0.125     ,  0.        ,  0.        ,  0.5       ,
                 0.        ,  0.125     ])
+
+        :arg str key: link attribute key (optional)
         """
         def t_func(x, xT):
             return x * x * x
         T = self.nsi_indegree() * self.nsi_outdegree()
-        return self._motif_clustering_helper(t_func, T, nsi=True)
+        return self._motif_clustering_helper(t_func, T, key=key, nsi=True)
 
-    @cached_const('nsi', 'local midemotif',
-                  'local nsi mid. motif clustering coefficient')
-    def nsi_local_midmotif_clustering(self):
+    @cached_var('nsi local midemotif',
+                'local nsi mid. motif clustering coefficient')
+    def nsi_local_midmotif_clustering(self, key=None):
         """
         For each node, return the nsi clustering coefficient with respect to
         the mid motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
+
+        Reference: [Zemp2014]_
 
         **Examples:**
 
@@ -2199,18 +2305,25 @@ can only take values <<in>> or <<out>>."
         >>> net.splitted_copy(node=4).local_midmotif_clustering()
         Calculating local mid. motif clustering coefficient...
         array([ 0. ,  0. ,  0. ,  1. ,  0.8,  0. ,  0.8])
+
+        :arg str key: link attribute key (optional)
         """
         def t_func(x, xT):
             return x * xT * x
         T = self.nsi_indegree() * self.nsi_outdegree()
-        return self._motif_clustering_helper(t_func, T, nsi=True)
+        return self._motif_clustering_helper(t_func, T, key=key, nsi=True)
 
-    @cached_const('nsi', 'local inemotif',
-                  'local nsi in motif clustering coefficient')
-    def nsi_local_inmotif_clustering(self):
+    @cached_var('nsi local inemotif',
+                'local nsi in motif clustering coefficient')
+    def nsi_local_inmotif_clustering(self, key=None):
         """
         For each node, return the nsi clustering coefficient with respect to
         the in motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
+
+        Reference: [Zemp2014]_
 
         **Examples:**
 
@@ -2234,18 +2347,25 @@ can only take values <<in>> or <<out>>."
         Calculating local in motif clustering coefficient...
         array([ 0.        ,  0.5       ,  0.66666667,  0.        ,  1.        ,
                 0.        ,  0.5       ])
+
+        :arg str key: link attribute key (optional)
         """
         def t_func(x, xT):
             return xT * x * x
         T = self.nsi_indegree()**2
-        return self._motif_clustering_helper(t_func, T, nsi=True)
+        return self._motif_clustering_helper(t_func, T, key=key, nsi=True)
 
-    @cached_const('nsi', 'local outemotif',
-                  'local nsi out motif clustering coefficient')
-    def nsi_local_outmotif_clustering(self):
+    @cached_var('nsi local outemotif',
+                'local nsi out motif clustering coefficient')
+    def nsi_local_outmotif_clustering(self, key=None):
         """
         For each node, return the nsi clustering coefficient with respect to
         the out motif.
+
+        If a link attribute key is specified, return the associated link
+        weighted version
+
+        Reference: [Zemp2014]_
 
         **Examples:**
 
@@ -2269,11 +2389,13 @@ can only take values <<in>> or <<out>>."
         Calculating local out motif clustering coefficient...
         array([ 0.5       ,  0.5       ,  0.        ,  0.        ,  0.33333333,
                 1.        ,  0.5       ])
+
+        :arg str key: link attribute key (optional)
         """
         def t_func(x, xT):
             return x * x * xT
         T = self.nsi_outdegree()**2
-        return self._motif_clustering_helper(t_func, T, nsi=True)
+        return self._motif_clustering_helper(t_func, T, key=key, nsi=True)
 
     @cached_const('base', 'transitivity', 'transitivity coefficient (C_1)')
     def transitivity(self):

--- a/tests/test_core/TestNetwork.py
+++ b/tests/test_core/TestNetwork.py
@@ -65,6 +65,19 @@ def comparePermutations(net, permutations, measures):
         pool.join()
 
 
+def compareNSI(net, nsi_measures):
+    net_copies = [net.splitted_copy(node=i) for i in range(net.N)]
+    for nsi_measure in nsi_measures:
+        print nsi_measure
+        for i, netc in enumerate(net_copies):
+            # test for invariance of old nodes
+            assert np.allclose(getattr(netc, nsi_measure)()[0:net.N],
+                               getattr(net, nsi_measure)())
+            # test for invariance of origianl and copied node
+            assert np.allclose(getattr(netc, nsi_measure)()[i],
+                               getattr(netc, nsi_measure)()[-1])
+
+
 # -----------------------------------------------------------------------------
 # stability
 # -----------------------------------------------------------------------------
@@ -110,3 +123,29 @@ def testPermutations():
             "local_vulnerability", "coreness", "msf_synchronizability",
             "spreading", "nsi_spreading"
         ])
+
+
+def testNSI():
+    """
+    Consistency of nsi measures with splitted network copies
+    """
+    dnw = Network.SmallDirectedTestNetwork()
+    nw = Network.SmallTestNetwork()
+    nsi_measures = ["nsi_degree", "nsi_indegree", "nsi_outdegree",
+                    "nsi_closeness", "nsi_harmonic_closeness",
+                    "nsi_exponential_closeness", "nsi_arenas_betweenness",
+                    "nsi_spreading",
+                    "nsi_local_cyclemotif_clustering",
+                    "nsi_local_midmotif_clustering",
+                    "nsi_local_inmotif_clustering",
+                    "nsi_local_outmotif_clustering"]
+    nsi_undirected_measures = ["nsi_local_clustering",
+                               "nsi_average_neighbors_degree",
+                               "nsi_max_neighbors_degree",
+                               "nsi_eigenvector_centrality",
+                               "nsi_local_clustering",
+                               "nsi_local_soffer_clustering",
+                               "nsi_newman_betweenness"]
+
+    compareNSI(dnw, nsi_measures)
+    compareNSI(nw, nsi_measures + nsi_undirected_measures)

--- a/tests/test_core/TestNetwork.py
+++ b/tests/test_core/TestNetwork.py
@@ -68,14 +68,19 @@ def comparePermutations(net, permutations, measures):
 def compareNSI(net, nsi_measures):
     net_copies = [net.splitted_copy(node=i) for i in range(net.N)]
     for nsi_measure in nsi_measures:
+        if isinstance(nsi_measure, tuple):
+            kwargs = nsi_measure[1]
+            nsi_measure = nsi_measure[0]
+        else:
+            kwargs = {}
         print nsi_measure
         for i, netc in enumerate(net_copies):
             # test for invariance of old nodes
-            assert np.allclose(getattr(netc, nsi_measure)()[0:net.N],
-                               getattr(net, nsi_measure)())
-            # test for invariance of origianl and copied node
-            assert np.allclose(getattr(netc, nsi_measure)()[i],
-                               getattr(netc, nsi_measure)()[-1])
+            assert np.allclose(getattr(netc, nsi_measure)(**kwargs)[0:net.N],
+                               getattr(net, nsi_measure)(**kwargs))
+            # test for invariance of origianl and new splitted node
+            assert np.allclose(getattr(netc, nsi_measure)(**kwargs)[i],
+                               getattr(netc, nsi_measure)(**kwargs)[-1])
 
 
 # -----------------------------------------------------------------------------
@@ -131,6 +136,7 @@ def testNSI():
     """
     dnw = Network.SmallDirectedTestNetwork()
     nw = Network.SmallTestNetwork()
+
     nsi_measures = ["nsi_degree", "nsi_indegree", "nsi_outdegree",
                     "nsi_closeness", "nsi_harmonic_closeness",
                     "nsi_exponential_closeness", "nsi_arenas_betweenness",
@@ -138,7 +144,19 @@ def testNSI():
                     "nsi_local_cyclemotif_clustering",
                     "nsi_local_midmotif_clustering",
                     "nsi_local_inmotif_clustering",
-                    "nsi_local_outmotif_clustering"]
+                    "nsi_local_outmotif_clustering",
+                    ("nsi_degree", {"key": "link_weights"}),
+                    ("nsi_indegree", {"key": "link_weights"}),
+                    ("nsi_outdegree", {"key": "link_weights"}),
+                    ("nsi_local_cyclemotif_clustering",
+                     {"key": "link_weights"}),
+                    ("nsi_local_midmotif_clustering",
+                     {"key": "link_weights"}),
+                    ("nsi_local_inmotif_clustering",
+                     {"key": "link_weights"}),
+                    ("nsi_local_outmotif_clustering",
+                     {"key": "link_weights"})]
+
     nsi_undirected_measures = ["nsi_local_clustering",
                                "nsi_average_neighbors_degree",
                                "nsi_max_neighbors_degree",

--- a/tests/test_core/TestNetwork.py
+++ b/tests/test_core/TestNetwork.py
@@ -90,14 +90,15 @@ def testPermutations():
     """
     comparePermutations(
         Network.SmallTestNetwork(), 3, [
-            "degree", "indegree", "outdegree", "nsi_degree",
-            "nsi_average_neighbors_degree", "nsi_max_neighbors_degree",
-            "undirected_adjacency", "laplacian", "nsi_laplacian",
-            "local_clustering", "global_clustering", "transitivity",
-            ("higher_order_transitivity", [4]), ("local_cliquishness", [4]),
-            ("local_cliquishness", [5]), "nsi_twinness", "assortativity",
-            "nsi_local_clustering", "nsi_global_clustering",
-            "nsi_transitivity", "nsi_local_soffer_clustering", "path_lengths",
+            "degree", "indegree", "outdegree", "nsi_degree", "nsi_indegree",
+            "nsi_outdegree", "nsi_average_neighbors_degree",
+            "nsi_max_neighbors_degree", "undirected_adjacency", "laplacian",
+            "nsi_laplacian", "local_clustering", "global_clustering",
+            "transitivity", ("higher_order_transitivity", [4]),
+            ("local_cliquishness", [4]), ("local_cliquishness", [5]),
+            "nsi_twinness", "assortativity", "nsi_local_clustering",
+            "nsi_global_clustering", "nsi_transitivity",
+            "nsi_local_soffer_clustering", "path_lengths",
             "average_path_length", "nsi_average_path_length", "diameter",
             "matching_index", "link_betweenness", "betweenness",
             "eigenvector_centrality", "nsi_eigenvector_centrality", "pagerank",


### PR DESCRIPTION
New methods =nsi_indegree= and =nsi_outdegree= introduced so far.
_Open Questions / Points to discuss_
- Shall the =typical_weight= fuctionality also be available for directed degrees?
- Shall there be a =link_attribute= keyword for all the degree measues, by that including =strength= measures?
- Does it make any sense to have the =sp_nsi_diag_k= and the =sp_nsi_diag_k_inv= methods written in the code between all the degree measures? If no, shall they be moved to another sensible place?