### PR TITLE
Changed doctest of white_noise_surrogates

### DIFF
--- a/pyunicorn/timeseries/surrogates.py
+++ b/pyunicorn/timeseries/surrogates.py
@@ -384,9 +384,9 @@ class Surrogates(object):
         >>> surrogates = Surrogates.\
                 SmallTestData().white_noise_surrogates(ts)
         >>> np.histogram(ts[0,:])[0]
-        array([21, 12,  9, 15, 34, 35, 18, 12, 16, 28])
+        array([21, 12,  9, 15, 33, 36, 18, 12, 16, 28])
         >>> np.histogram(surrogates[0,:])[0]
-        array([21, 12,  9, 15, 34, 35, 18, 12, 16, 28])
+        array([21, 12,  9, 15, 33, 36, 18, 12, 16, 28])
 
         :type original_data: 2D array [index, time]
         :arg original_data: The original time series.


### PR DESCRIPTION
I changed the doctest of timeseries.surrogates.Surrogates.white_noise_surrogates to pass the doctest.
I don't know why it actually started to fail, the only thing could be a change in `np.histogram`, which seems very unlikely...