### PR TITLE
fix version in setup

### DIFF
--- a/pyunicorn/__init__.py
+++ b/pyunicorn/__init__.py
@@ -40,14 +40,13 @@ To Do
 import os
 import sys
 
-from setup import __version__
-
-from .utils import mpi
-from .core import *
+from pyunicorn.utils import mpi
+from pyunicorn.core import *
 
 sys.path.insert(0, os.path.abspath('../..'))
 
 
+__version__ = '0.6.1'
 __author__ = "Jonathan F. Donges <donges@pik-potsdam.de>"
 __copyright__ = \
     "Copyright (C) 2008-2019 Jonathan F. Donges and pyunicorn authors"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@
 
 from setuptools import setup
 from setuptools.extension import Extension
+import imp
 
 import numpy as np
 
@@ -29,11 +30,7 @@ except ImportError:
 
 # -----------------------------------------------------------------------------
 
-
-__version__ = '0.6.1'
-
-
-# -----------------------------------------------------------------------------
+__version__ = imp.load_source("", "pyunicorn/__init__.py").__version__
 
 
 def main():


### PR DESCRIPTION
In __init__.py, having `import setup` causes conflicts with other setup.py from other packages, this is a cleaner way to import the code version.
I also added absolute import in __init__.py, to be safer (my pip complained about that as well).
Otherwise, great code thanks!