### PR TITLE
Cartopy plotting instead of pyngl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,8 @@ Optional *(used only in certain classes and methods)*:
   - `Matplotlib <http://matplotlib.org/>`_
   - `Matplotlib Basemap Toolkit <http://matplotlib.org/basemap/>`_
     (for drawing maps)
+  - `Cartopy <https://scitools.org.uk/cartopy/docs/latest/index.html>`_
+    (for some plotting features)
   - `mpi4py <https://bitbucket.org/mpi4py/mpi4py>`_
     (for parallelizing costly computations)
   - `Sphinx <http://sphinx-doc.org/>`_

--- a/examples/tutorials/climate_network.py
+++ b/examples/tutorials/climate_network.py
@@ -14,15 +14,13 @@ Copyright 2008-2022.
 """
 
 import numpy as np
+from matplotlib import pyplot as plt
 
 from pyunicorn import climate
 
-# Test if Ngl package is installed
-try:
-    import Ngl
-    ngl_flag = True
-except ImportError:
-    ngl_flag = False
+import cartopy.crs as ccrs
+import cartopy.feature as cf
+
 #
 #  Settings
 #
@@ -94,13 +92,10 @@ data = climate.ClimateData.Load(
     window=WINDOW, time_cycle=TIME_CYCLE)
 
 #  Print some information on the data set
-print(data)
 
-#
-#  Create a MapPlots object to manage 2D-plotting on the sphere
-#
-if ngl_flag:
-    map_plots = climate.MapPlots(data.grid, DATA_SOURCE)
+data.grid.print_grid_size()
+
+
 #
 #  Generate climate network using various procedures
 #
@@ -112,6 +107,8 @@ if ngl_flag:
 #  fixed threshold
 net = climate.TsonisClimateNetwork(
     data, threshold=THRESHOLD, winter_only=WINTER_ONLY)
+
+print("net created")
 
 #  Create a climate network based on Pearson correlation without lag and with
 #  fixed link density
@@ -161,27 +158,25 @@ np.savetxt("degree.txt", degree)
 #  Plotting
 #
 
+# create a Cartopy plot instance called cn_plot (cn for climate network)
+# from the data with tite DATA_SOURCE
+cn_plot = climate.CartopyPlots(data.grid, DATA_SOURCE)
+
 #  Add network measures to the plotting queue
-if ngl_flag:
-    map_plots.add_dataset("Degree", degree)
-    map_plots.add_dataset("Closeness", closeness)
-    map_plots.add_dataset("Betweenness (log10)", np.log10(betweenness + 1))
-    map_plots.add_dataset("Clustering", clustering)
-    map_plots.add_dataset("Average link distance", ald)
-    map_plots.add_dataset("Maximum link distance", mld)
+cn_plot.add_dataset("Degree", degree)
+cn_plot.add_dataset("Closeness", closeness)
+cn_plot.add_dataset("Betweenness (log10)", np.log10(betweenness + 1))
+cn_plot.add_dataset("Clustering", clustering)
+cn_plot.add_dataset("Average link distance", ald)
+cn_plot.add_dataset("Maximum link distance", mld)
 
-    #  Change the map projection
-    map_plots.resources.mpProjection = "Robinson"
-    map_plots.resources.mpCenterLonF = 0
+# before plotting, we can change some things, like cmap
+ax = plt.set_cmap('plasma')
 
-    #  Change the levels of contouring
-    map_plots.resources.cnLevelSelectionMode = "EqualSpacedLevels"
-    map_plots.resources.cnMaxLevelCount = 20
-
-    # map_plots.resources.cnRasterSmoothingOn = True
-    # map_plots.resources.cnFillMode = "AreaFill"
-
-    map_plots.generate_map_plots(file_name="climate_network_measures",
+# Plot with cartopy and matplotlib
+cn_plot.generate_plots(file_name="climate_network_measures",
                                  title_on=False, labels_on=True)
-else:
-    print("\nPlots can only be created when Ngl package is installed!")
+
+
+
+

--- a/src/pyunicorn/climate/__init__.py
+++ b/src/pyunicorn/climate/__init__.py
@@ -45,6 +45,7 @@ from .coupled_tsonis import CoupledTsonisClimateNetwork
 from .havlin import HavlinClimateNetwork
 from .hilbert import HilbertClimateNetwork
 from .map_plots import MapPlots
+from .cartopy_plots import CartopyPlots
 from .mutual_info import MutualInfoClimateNetwork
 from .partial_correlation import PartialCorrelationClimateNetwork
 from .rainfall import RainfallClimateNetwork

--- a/src/pyunicorn/climate/cartopy_plots.py
+++ b/src/pyunicorn/climate/cartopy_plots.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This file is part of pyunicorn.
+# Copyright (C) 2008--2022 Jonathan F. Donges and pyunicorn authors
+# URL: <http://www.pik-potsdam.de/members/donges/software>
+# License: BSD (3-clause)
+#
+# Please acknowledge and cite the use of this software and its authors
+# when results are used in publications or published elsewhere.
+#
+# You can use the following reference:
+# J.F. Donges, J. Heitzig, B. Beronov, M. Wiedermann, J. Runge, Q.-Y. Feng,
+# L. Tupikina, V. Stolbova, R.V. Donner, N. Marwan, H.A. Dijkstra,
+# and J. Kurths, "Unified functional network and nonlinear time series analysis
+# for complex systems science: The pyunicorn package"
+
+"""
+Provides classes for analyzing spatially embedded complex networks, handling
+multivariate data and generating time series surrogates.
+"""
+
+import os
+import glob
+# time handling
+# import datetime
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+#  Import Ngl support functions for plotting, map projections etc.
+try:
+    import cartopy
+except ImportError:
+    print("climate: Package cartopy could not be loaded. Some functionality "
+          "in class MapPlots might not be available!")
+
+import cartopy.crs as ccrs
+
+#
+#  Define class CartopyPlots
+#
+
+
+class CartopyPlots:
+
+    """
+    Encapsulates map plotting functions via cartopy and matplotlib.
+
+    """
+
+    def __init__(self, grid, title):
+        """
+        Initialize an instance of MapPlots.
+
+        Plotting of maps is powered by PyNGL.
+
+        :type grid: :class:`.Grid`
+        :arg grid: The Grid object describing the map data to be plotted.
+        :arg str title: The title describing the map data.
+        """
+        self.grid = grid
+        """(Grid) - The Grid object describing the map data to be plotted."""
+        self.title = title
+        """(string) - The title describing the map data."""
+
+        #  Initialize list to store data sets and titles
+        self.map_data = []
+        """(list) - The list storing map data and titles."""
+        #  Also for multiple maps
+        self.map_mult_data = []
+        """(list) - The list storing map data and titles for multiple maps."""
+
+        #
+        #  Adjust cartopy settings, fine tuning can be done externally
+        #
+
+        # Specify Coordinate Refference System for Map Projection
+        projection = ccrs.Robinson()
+
+        # Specify CRS (where data should be plotted)
+        crs = ccrs.Robinson()
+
+        # create axes object having specific projection
+
+        lon_min = self.grid.boundaries()["lon_min"]
+        lon_max = self.grid.boundaries()["lon_max"]
+        lat_min = self.grid.boundaries()["lat_min"]
+        lat_max = self.grid.boundaries()["lat_max"]
+
+
+
+
+    def add_dataset(self, title, data):
+        """
+        Add a map data set for plotting.
+
+        Data sets are stored as dictionaries in the :attr:`map_data` list.
+
+        :arg str title: The string describing the data set.
+        :type data: 1D array [index]
+        :arg data: The numpy array containing the map to be drawn
+        """
+        self.map_data.append({"title": title, "data": data})
+
+    def generate_map_plots(self, file_name, title_on=True, labels_on=True):
+        """
+        Generate and save map plots.
+
+        Store the plots in the file indicated by ``file_name`` in the current
+        directory.
+
+        Map plots are stored in a PDF file, with each map occupying its own
+        page.
+
+        :arg str file_name: The name for the PDF file containing map plots.
+        :arg bool title_on: Determines, whether main title is plotted.
+        :arg bool labels_on: Determines whether individual map titles are
+            plotted.
+        """
+
+        plt.figure(dpi=150)
+        ax = plt.axes(projection=self.projection, frameon=True)
+
+        ax.set_extent([self.lon_min, self.lon_max, self.lat_min, self.lat_max], crs=self.crs)
+
+        # Draw gridlines in degrees over Mercator map
+        gl = ax.gridlines(crs=self.crs, draw_labels=True,
+                          linewidth=.6, color='gray', alpha=0.5, linestyle='-.')
+        gl.xlabel_style = {"size": 7}
+        gl.ylabel_style = {"size": 7}
+
+        #  Set plot title
+        # if title_on:
+        #     plt.title(f"{self.title}")
+
+        plt.show()
+
+        #
+        #  Generate map plots
+        #
+        # for dataset in self.map_data:
+        #     #  Set title
+        #
+        #     #  Generate map plot
+        #     cmap = Ngl.contour_map(wks, dataset["data"], resources)
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Created a new class CartopyPlots that generates mapplots via cartopy and matplotlib. For the user nothing changes, as everything is called as for MapPlots. A working example is now found in examples/tutorials/climate_network_cartopy_plotting.py