### PR TITLE
CI: add build jobs for macOS and Windows in `travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ jobs:
           language: shell
           before_install: 
             - choco install miniconda3 --params="'/S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda'"
-            - refreshenv; path
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,38 +3,29 @@ version: ~> 1.0
 # require the branch name to be master
 if: branch = master
 
-# # temporarily skip linux job matrix
-# language: python
-# python:
-#     # https://docs.travis-ci.com/user/languages/python/#python-versions
-#     - "3.8"
-#     - "3.9"
-#     - "3.10"
-#     - "3.11"
-#     - "3.12-dev"
-# matrix:
-#     fast_finish: true
+language: python
+python:
+    # https://docs.travis-ci.com/user/languages/python/#python-versions
+    - "3.8"
+    - "3.9"
+    - "3.10"
+    - "3.11"
+    - "3.12-dev"
+matrix:
+    fast_finish: true
 
-# arch: arm64
-# virt: lxd
-# os: linux
-# dist: focal
-# sudo: false
+arch: arm64
+virt: lxd
+os: linux
+dist: focal
+sudo: false
 
 jobs:
     include:
-    #     - os: osx
-    #       osx_image: xcode12.2
-    #       language: shell        # 'language: python' is not available on Travis CI macOS
-        - os: windows
-          language: shell
-          before_install:
-              - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
-              - travis_retry start /wait "" miniconda.exe /S
-              - conda config --set quiet yes --set always_yes yes --set changeps1 no
-              - travis_retry conda update -n base -c defaults conda
-              - travis_retry conda update --all
-              - conda config --set solver libmamba
+        - python: "3.11"
+          os: osx
+          osx_image: xcode12.2
+          language: shell        # 'language: python' is not available on Travis CI macOS
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,21 +49,25 @@ jobs:
         - os: windows
           language: shell
           before_install:
-            - export MINICONDA_PATH=$HOME/miniconda
-            - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
-            - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
-            - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
-            - choco install openssl.light
-            - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
-            - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
-            - echo "$PATH" | wc -c
-            - echo %WINDIR%
-            - source $MINICONDA_PATH/etc/profile.d/conda.sh
-            - hash -r
-            - python --version
-            - conda config --set quiet yes --set always_yes yes --set changeps1 no
-            - travis_retry conda update -n base -c defaults conda
-            - travis_retry conda update --all
+            # - export MINICONDA_PATH=$HOME/miniconda
+            # - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
+            # - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
+            # - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
+            # - choco install openssl.light
+            # - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
+            # - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
+            # - source $MINICONDA_PATH/etc/profile.d/conda.sh
+            # - hash -r
+            # - python --version
+            # - conda config --set quiet yes --set always_yes yes --set changeps1 no
+            # - travis_retry conda update -n base -c defaults conda
+            # - travis_retry conda update --all
+
+            - choco install python --version 3.11
+            - python -m pip install --upgrade pip
+          env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+          install:
+            - echo "trying pip install right away"
 
 before_install:
     # Python package manager
@@ -109,7 +113,6 @@ script:
     - travis_retry pip install -v -e ".[testing,docs]"
 
     # test suite
-    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then echo %WINDIR%; fi
     - tox -v
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,10 @@ jobs:
             - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
             - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
             - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
-            - choco install openssl.light
-            - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
+            # - choco install openssl.light
+            # - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
+            - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
+            - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=$MINICONDA_PATH_WIN
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
@@ -83,13 +85,14 @@ install:
     - travis_retry conda create -n test-env
     - eval "$(conda shell.bash hook)"
     - conda activate test-env
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.11; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.9; fi
     - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
     - travis_retry conda update  -c conda-forge --all
 
     # testing dependencies
     - travis_retry conda install -c conda-forge tox flake8 pylint pytest-xdist pytest-cov codecov
     - travis_retry conda install -c conda-forge networkx matplotlib cartopy sphinx
+    - travis_retry conda update  -c conda-forge --all
 
     # debugging info
     - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
     - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe; fi
-    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then miniconda.exe; else bash miniconda.sh -b -p $HOME/miniconda; fi
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then ./miniconda.exe; else bash miniconda.sh -b -p $HOME/miniconda; fi
     - export PATH="$HOME/miniconda/bin:$PATH"; hash -r
     - conda config --set quiet yes --set always_yes yes --set changeps1 no
     - travis_retry conda update -n base -c defaults conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,20 +49,26 @@ jobs:
         - os: windows
           language: shell
           before_install: 
-            # - export MINICONDA=$HOME/miniconda
-            # - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
-            # - choco install openssl.light
-            # - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
-            # - source $MINICONDA/etc/profile.d/conda.sh
-            # - hash -r
-            # - conda config --set quiet yes --set always_yes yes --set changeps1 no
-            # - travis_retry conda update -n base -c defaults conda
-            # - travis_retry conda update --all
-            # - conda config --set solver libmamba
+            - export MINICONDA=$HOME/miniconda
+            - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
+            - choco install openssl.light
+            - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
+            - echo original PATH $PATH
+            - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/bin||')
+            - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin||')
+            - echo manipulated PATH $PATH
+            - source $MINICONDA/Scripts/activate
+            - source $MINICONDA/etc/profile.d/conda.sh
+            - hash -r
+            - conda config --set quiet yes --set always_yes yes --set changeps1 no
+            - travis_retry conda update -n base -c defaults conda
+            - travis_retry conda update --all
+            - conda config --set solver libmamba
 
-            - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
-            - wait
-            - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda
+            # install via exe
+            # - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
+            # - echo 'downloaded miniconda.exe'
+            # - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
 
             - choco install python --version 3.11
             - python -m pip install --upgrade pip
-          env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+          env: PATH=/c/Python311:/c/Python311/Scripts:$PATH
           install:
             - echo "trying pip install right away"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,12 @@ jobs:
         - os: windows
           language: shell
           before_install: 
-            - choco install miniconda3 --params="'/S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda'"
-            - refreshenv
-            - path
+            - export MINICONDA=$HOME/miniconda
+            - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
+            - choco install openssl.light
+            - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
+            - source $MINICONDA/etc/profile.d/conda.sh
+            - hash -r
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,44 @@ version: ~> 1.0
 # require the branch name to be master
 if: branch = master
 
-language: python
-python:
-    # https://docs.travis-ci.com/user/languages/python/#python-versions
-    - "3.8"
-    - "3.9"
-    - "3.10"
-    - "3.11"
-    - "3.12-dev"
-matrix:
-    fast_finish: true
-
-arch: arm64
-virt: lxd
-os: linux
-dist: focal
-sudo: false
-
 jobs:
     include:
-        - python: "3.11"
-          os: osx
+        - os: linux
+          dist: focal
+          arch: arm64
+          virt: lxd
+          sudo: false
+          language: python
+          python: "3.8"
+        - os: linux
+          dist: focal
+          arch: arm64
+          virt: lxd
+          sudo: false
+          language: python
+          python: "3.9"
+        - os: linux
+          dist: focal
+          arch: arm64
+          virt: lxd
+          sudo: false
+          language: python
+          python: "3.10"
+        - os: linux
+          dist: focal
+          arch: arm64
+          virt: lxd
+          sudo: false
+          language: python
+          python: "3.11"
+        - os: linux
+          dist: focal
+          arch: arm64
+          virt: lxd
+          sudo: false
+          language: python
+          python: "3.12-dev"
+        - os: osx
           osx_image: xcode12.2
           language: shell        # 'language: python' is not available on Travis CI macOS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ arch: arm64
 virt: lxd
 language: generic
 env:
-  global:
-    - ARCH=Linux-aarch64
-    - SED=sed
-
   jobs:
     - PYTHON=3.12
     - PYTHON=3.11
@@ -47,7 +43,9 @@ env:
     - PYTHON=3.9
     - PYTHON=3.8
 
-before_install:
+before_install: export ARCH=Linux-aarch64 SED=sed
+
+install:
   - | # install Python via Miniconda
     travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-${ARCH}.sh -O miniconda.sh
     bash miniconda.sh -b -p $HOME/miniconda
@@ -72,19 +70,18 @@ before_install:
     conda info -a
     conda list
 
-install:
+script:
   - | # limit procs to available cores (use GNU `sed`, fail if pattern not found)
-    [ "${TRAVIS_OS_NAME}" = "osx" ] && brew install gnu-sed || true
-    ${SED} -i "/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}" setup.py
-    ${SED} -i "/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}" setup.cfg
-    ${SED} -i "/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}" pyproject.toml
-    ${SED} -i "/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}" pyproject.toml
+    ${SED} -i '/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}' setup.py
+    ${SED} -i '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg
+    ${SED} -i '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml
+    ${SED} -i '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml
 
   # install self (and dependencies, if on Windows)
   - travis_retry pip install -v -e ".[tests,docs]"
 
-# run test suite
-script: tox -v
+  # run test suite
+  - tox -v
 
 # report statistics
 after_success: codecov
@@ -100,16 +97,15 @@ jobs:
     - os: osx
       osx_image: xcode14
       language: shell
-      env:
-        - ARCH=MacOSX-x86_64
-        - SED=gsed
+      before_install: export ARCH=MacOSX-x86_64 SED=gsed
+      before_script: brew install gnu-sed
 
     - os: windows
       language: shell
-      env:
-        - ARCH=Windows-x86_64
-        - PATH=/c/Python${PYTHON/.}:/c/Python${PYTHON/.}/Scripts:${PATH}
       before_install:
+        - export ARCH=Windows-x86_64 SED=sed
+        - export PATH=/c/Python${PYTHON/.}:/c/Python${PYTHON/.}/Scripts:${PATH}
+      install:
         - | # install Python via Chocolatey
           travis_retry choco install python --version ${PYTHON}
           travis_retry python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ jobs:
         - os: windows
           language: shell
           before_install:
-              - travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
-              - ./miniconda.exe /InstallationType=JustMe /AddToPath=1 /S /D=$HOME\miniconda
+              - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath:1 /S /D=%UserProfile%\miniconda'"
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,112 +1,115 @@
+
+# -----------------------------------------------------------------------------
+# documentation & validation
+# -----------------------------------------------------------------------------
+
+# - https://docs.travis-ci.com/user/reference/overview
+# - https://docs.travis-ci.com/user/build-matrix/
+# - https://docs.travis-ci.com/user/multi-os/
+
+# - https://docs.travis-ci.com/user/build-config-validation/
+# - https://config.travis-ci.com/explore
+
+# -----------------------------------------------------------------------------
+# meta
+# -----------------------------------------------------------------------------
+
+# enable build config validation
 version: ~> 1.0
 
-# require the branch name to be master
+# save Travis budget
 if: branch = master
 
-jobs:
-    include:
-        # # linux jobs
-        # - os: linux
-        #   dist: focal
-        #   arch: arm64
-        #   virt: lxd
-        #   sudo: false
-        #   language: python
-        #   python: "3.8"
-        # - os: linux
-        #   dist: focal
-        #   arch: arm64
-        #   virt: lxd
-        #   sudo: false
-        #   language: python
-        #   python: "3.9"
-        # - os: linux
-        #   dist: focal
-        #   arch: arm64
-        #   virt: lxd
-        #   sudo: false
-        #   language: python
-        #   python: "3.10"
-        # - os: linux
-        #   dist: focal
-        #   arch: arm64
-        #   virt: lxd
-        #   sudo: false
-        #   language: python
-        #   python: "3.11"
-        # - os: linux
-        #   dist: focal
-        #   arch: arm64
-        #   virt: lxd
-        #   sudo: false
-        #   language: python
-        #   python: "3.12-dev"
-        # # macOS job
-        # - os: osx
-        #   osx_image: xcode12.2
-        #   language: shell        # 'language: python' is not available on Travis CI macOS
-        # Windows job
-        - os: windows
-          language: shell
-          env: 
-            - PATH=/c/Python311:/c/Python311/Scripts:$PATH
-            - WINDIR=C:\Windows
-          before_install:
-            - choco install python --version 3.11.6
-            - python -m pip install --upgrade pip
-          install:
-            - echo using pip install on windows
+# report outcomes
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
+# -----------------------------------------------------------------------------
+# default jobs: Linux, all Python versions
+# -----------------------------------------------------------------------------
+
+os: linux
+dist: focal
+arch: arm64
+virt: lxd
+language: generic
+env:
+  global:
+    - ARCH=Linux-aarch64
+    - SED=sed
+
+  jobs:
+    - PYTHON=3.12
+    - PYTHON=3.11
+    - PYTHON=3.10
+    - PYTHON=3.9
+    - PYTHON=3.8
 
 before_install:
-    # Python package manager
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"; hash -r
-    - conda config --set quiet yes --set always_yes yes --set changeps1 no
-    - travis_retry conda update -n base -c defaults conda
-    - travis_retry conda update --all
-    - conda config --set solver libmamba
+  - | # install Python via Miniconda
+    travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-${ARCH}.sh -O miniconda.sh
+    bash miniconda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"; hash -r
+    conda config --set quiet yes --set always_yes yes --set changeps1 no
+  - |
+    travis_retry conda update -n base -c defaults conda
+    travis_retry conda update --all
+    conda config --set solver libmamba
+    conda info -a
+    conda list
+    travis_retry conda create -n test-env
+    eval "$(conda shell.bash hook)"
+    conda activate test-env
+    travis_retry conda install -c conda-forge python=${PYTHON}
 
-    # debugging info
-    - conda info -a
-    - conda list
+  - | # install dependencies
+    travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
+    travis_retry conda update  -c conda-forge --all
+    travis_retry conda install -c conda-forge tox flake8 pylint pytest-xdist pytest-cov codecov
+    travis_retry conda install -c conda-forge networkx matplotlib cartopy sphinx
+    conda info -a
+    conda list
 
 install:
-    # runtime dependencies
-    - travis_retry conda create -n test-env
-    - eval "$(conda shell.bash hook)"
-    - conda activate test-env
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.9; fi
-    - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
-    - travis_retry conda update  -c conda-forge --all
+  - | # limit procs to available cores (use GNU `sed`, fail if pattern not found)
+    [ "${TRAVIS_OS_NAME}" = "osx" ] && brew install gnu-sed || true
+    ${SED} -i "/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}" setup.py
+    ${SED} -i "/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}" setup.cfg
+    ${SED} -i "/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}" pyproject.toml
+    ${SED} -i "/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}" pyproject.toml
 
-    # testing dependencies
-    - travis_retry conda install -c conda-forge tox flake8 pylint pytest-xdist pytest-cov codecov
-    - travis_retry conda install -c conda-forge networkx matplotlib cartopy sphinx
+  # install self (and dependencies, if on Windows)
+  - travis_retry pip install -v -e ".[tests,docs]"
 
-    # debugging info
-    - conda info -a
-    - conda list
+# run test suite
+script: tox -v
 
-before_script:
-    # limit parallel processes to available cores (error if pattern not found)
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}' setup.py; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
+# report statistics
+after_success: codecov
 
-script:
-    # package
-    - travis_retry pip install -v -e ".[testing,docs]"
+# -----------------------------------------------------------------------------
+# modified jobs: OSX + Windows, newest Python version
+# (inherit only 1st `env.jobs` entry)
+# -----------------------------------------------------------------------------
 
-    # test suite
-    - tox -v
+jobs:
+  fast_finish: true
+  include:
+    - os: osx
+      osx_image: xcode14
+      language: shell
+      env:
+        - ARCH=MacOSX-x86_64
+        - SED=gsed
 
-after_success:
-    - codecov
-
-notifications:
-    email:
-        on_success: change
-        on_failure: always
+    - os: windows
+      language: shell
+      env:
+        - ARCH=Windows-x86_64
+        - PATH=/c/Python${PYTHON/.}:/c/Python${PYTHON/.}/Scripts:${PATH}
+      before_install:
+        - | # install Python via Chocolatey
+          travis_retry choco install python --version ${PYTHON}
+          travis_retry python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,11 @@ jobs:
             - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
             - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
             - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
-            - export WINDIR=%SystemRoot%
             - choco install openssl.light
             - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
+            - echo $PATH
+            - export WINDIR=%SystemRoot%
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
             - python --version
@@ -108,6 +109,7 @@ script:
     - travis_retry pip install -v -e ".[testing,docs]"
 
     # test suite
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export WINDIR=%SystemRoot%; fi
     - tox -v
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,19 @@ if: branch = master
 
 jobs:
     include:
-        - os: osx
-          osx_image: xcode12.2
-          language: shell        # 'language: python' is an error on Travis CI macOS
+    #     - os: osx
+    #       osx_image: xcode12.2
+    #       language: shell        # 'language: python' is not available on Travis CI macOS
+        - os: windows
+          language: shell
+
 
 before_install:
     # Python package manager
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-    - bash miniconda.sh -b -p $HOME/miniconda
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe; fi
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then miniconda.exe; else bash miniconda.sh -b -p $HOME/miniconda; fi
     - export PATH="$HOME/miniconda/bin:$PATH"; hash -r
     - conda config --set quiet yes --set always_yes yes --set changeps1 no
     - travis_retry conda update -n base -c defaults conda
@@ -47,8 +51,7 @@ install:
     - travis_retry conda create -n test-env
     - eval "$(conda shell.bash hook)"
     - conda activate test-env
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry conda install -c conda-forge python=3.11; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.11; fi
     - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
     - travis_retry conda update  -c conda-forge --all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,16 +49,20 @@ jobs:
         - os: windows
           language: shell
           before_install: 
-            - export MINICONDA=$HOME/miniconda
-            - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
-            - choco install openssl.light
-            - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
-            - source $MINICONDA/etc/profile.d/conda.sh
-            - hash -r
-            - conda config --set quiet yes --set always_yes yes --set changeps1 no
-            - travis_retry conda update -n base -c defaults conda
-            - travis_retry conda update --all
-            - conda config --set solver libmamba
+            # - export MINICONDA=$HOME/miniconda
+            # - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
+            # - choco install openssl.light
+            # - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
+            # - source $MINICONDA/etc/profile.d/conda.sh
+            # - hash -r
+            # - conda config --set quiet yes --set always_yes yes --set changeps1 no
+            # - travis_retry conda update -n base -c defaults conda
+            # - travis_retry conda update --all
+            # - conda config --set solver libmamba
+
+            - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
+            - wait
+            - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,8 @@ jobs:
             - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
             - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
             - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
-            # - choco install openssl.light
-            # - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
-            - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
-            - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=$MINICONDA_PATH_WIN
+            - choco install openssl.light
+            - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,44 +5,56 @@ if: branch = master
 
 jobs:
     include:
-        - os: linux
-          dist: focal
-          arch: arm64
-          virt: lxd
-          sudo: false
-          language: python
-          python: "3.8"
-        - os: linux
-          dist: focal
-          arch: arm64
-          virt: lxd
-          sudo: false
-          language: python
-          python: "3.9"
-        - os: linux
-          dist: focal
-          arch: arm64
-          virt: lxd
-          sudo: false
-          language: python
-          python: "3.10"
-        - os: linux
-          dist: focal
-          arch: arm64
-          virt: lxd
-          sudo: false
-          language: python
-          python: "3.11"
-        - os: linux
-          dist: focal
-          arch: arm64
-          virt: lxd
-          sudo: false
-          language: python
-          python: "3.12-dev"
-        - os: osx
-          osx_image: xcode12.2
-          language: shell        # 'language: python' is not available on Travis CI macOS
+        # # linux jobs
+        # - os: linux
+        #   dist: focal
+        #   arch: arm64
+        #   virt: lxd
+        #   sudo: false
+        #   language: python
+        #   python: "3.8"
+        # - os: linux
+        #   dist: focal
+        #   arch: arm64
+        #   virt: lxd
+        #   sudo: false
+        #   language: python
+        #   python: "3.9"
+        # - os: linux
+        #   dist: focal
+        #   arch: arm64
+        #   virt: lxd
+        #   sudo: false
+        #   language: python
+        #   python: "3.10"
+        # - os: linux
+        #   dist: focal
+        #   arch: arm64
+        #   virt: lxd
+        #   sudo: false
+        #   language: python
+        #   python: "3.11"
+        # - os: linux
+        #   dist: focal
+        #   arch: arm64
+        #   virt: lxd
+        #   sudo: false
+        #   language: python
+        #   python: "3.12-dev"
+        # # macOS job
+        # - os: osx
+        #   osx_image: xcode12.2
+        #   language: shell        # 'language: python' is not available on Travis CI macOS
+        # Windows job
+        - os: windows
+          language: shell
+          before_install: 
+            - choco install miniconda3 --params="'/S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda'"
+            - refreshenv; path
+            - conda config --set quiet yes --set always_yes yes --set changeps1 no
+            - travis_retry conda update -n base -c defaults conda
+            - travis_retry conda update --all
+            - conda config --set solver libmamba
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ jobs:
           language: shell
           before_install: 
             - choco install miniconda3 --params="'/S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda'"
+            - refreshenv
+            - path
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all
@@ -75,7 +77,7 @@ install:
     - travis_retry conda create -n test-env
     - eval "$(conda shell.bash hook)"
     - conda activate test-env
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.11; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.9; fi
     - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
     - travis_retry conda update  -c conda-forge --all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+# This file is part of pyunicorn.
+# Copyright (C) 2008--2024 Jonathan F. Donges and pyunicorn authors
+# URL: <http://www.pik-potsdam.de/members/donges/software>
+# License: BSD (3-clause)
 
-# -----------------------------------------------------------------------------
-# documentation & validation
-# -----------------------------------------------------------------------------
+
+# documentation & validation ==================================================
 
 # - https://docs.travis-ci.com/user/reference/overview
 # - https://docs.travis-ci.com/user/build-matrix/
@@ -10,9 +13,8 @@
 # - https://docs.travis-ci.com/user/build-config-validation/
 # - https://config.travis-ci.com/explore
 
-# -----------------------------------------------------------------------------
-# meta
-# -----------------------------------------------------------------------------
+
+# meta ========================================================================
 
 # enable build config validation
 version: ~> 1.0
@@ -26,9 +28,8 @@ notifications:
     on_success: change
     on_failure: always
 
-# -----------------------------------------------------------------------------
-# default jobs: Linux, all Python versions
-# -----------------------------------------------------------------------------
+
+# default jobs: Linux, all Python versions ====================================
 
 os: linux
 dist: focal
@@ -86,10 +87,14 @@ script:
 # report statistics
 after_success: codecov
 
-# -----------------------------------------------------------------------------
-# modified jobs: OSX + Windows, newest Python version
+
+# modified jobs: OSX + Windows, newest Python version =========================
 # (inherit only 1st `env.jobs` entry)
-# -----------------------------------------------------------------------------
+
+addons:
+  homebrew:
+    update: false
+    packages: gnu-sed
 
 jobs:
   fast_finish: true
@@ -97,8 +102,9 @@ jobs:
     - os: osx
       osx_image: xcode14
       language: shell
-      before_install: export ARCH=MacOSX-x86_64 SED=gsed
-      before_script: brew install gnu-sed
+      before_install:
+        - export ARCH=MacOSX-x86_64 SED=gsed
+        - export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
 
     - os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
     - eval "$(conda shell.bash hook)"
     - conda activate test-env
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=3.11; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry conda install -c conda-forge python=3.11; fi
     - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
     - travis_retry conda update  -c conda-forge --all
 
@@ -62,10 +62,14 @@ install:
 
 before_script:
     # limit parallel processes to available cores (error if pattern not found)
-    - sed -i '/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}' setup.py
-    - sed -i '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg
-    - sed -i '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml
-    - sed -i '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}' setup.py; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}' setup.py; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
 
 script:
     # package

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,25 @@ version: ~> 1.0
 if: branch = master
 
 # # temporarily skip linux job matrix
-language: python
-os:
-    - linux
-    - osx
-python:
-    # https://docs.travis-ci.com/user/languages/python/#python-versions
-    - "3.8"
-    - "3.9"
-    - "3.10"
-    - "3.11"
-    - "3.12-dev"
-matrix:
-    fast_finish: true
+# language: python
+# python:
+#     # https://docs.travis-ci.com/user/languages/python/#python-versions
+#     - "3.8"
+#     - "3.9"
+#     - "3.10"
+#     - "3.11"
+#     - "3.12-dev"
+# matrix:
+#     fast_finish: true
+
+# arch: arm64
+# virt: lxd
+# os: linux
+# dist: focal
+# sudo: false
 
 jobs:
     include:
-        - os: linux
-          arch: arm64
-          virt: lxd
-          os: linux
-          dist: focal
-          sudo: false
         - os: osx
           osx_image: xcode12.2
           language: shell        # 'language: python' is an error on Travis CI macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         # Windows job
         - os: windows
           language: shell
-          before_install: 
+          before_install:
             - export MINICONDA_PATH=$HOME/miniconda
             - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
             - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
@@ -62,7 +62,6 @@ jobs:
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all
-            - # conda config --set solver libmamba # libmamba solver is not available somehow
 
 before_install:
     # Python package manager
@@ -84,7 +83,7 @@ install:
     - travis_retry conda create -n test-env
     - eval "$(conda shell.bash hook)"
     - conda activate test-env
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.9; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; else travis_retry conda install -c conda-forge python=3.11; fi
     - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
     - travis_retry conda update  -c conda-forge --all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,12 @@ jobs:
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all
+          install:
+            # runtime dependencies
+            - travis_retry conda create -n test-env
+            - eval "$(conda shell.bash hook)"
+            - conda activate test-env
+            - travis_retry conda install -c conda-forge python=3.9
 
 before_install:
     # Python package manager
@@ -89,8 +95,7 @@ install:
 
     # testing dependencies
     - travis_retry conda install -c conda-forge tox flake8 pylint pytest-xdist pytest-cov codecov
-    - travis_retry conda install -c conda-forge networkx cartopy sphinx
-    - travis_retry conda update  -c conda-forge --all
+    - travis_retry conda install -c conda-forge networkx matplotlib cartopy sphinx
 
     # debugging info
     - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
         - os: windows
           language: shell
           before_install:
-              - travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
-              - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda
+              - curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o miniconda.exe
+              - start /wait "" miniconda.exe /S
               - conda config --set quiet yes --set always_yes yes --set changeps1 no
               - travis_retry conda update -n base -c defaults conda
               - travis_retry conda update --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
         - os: windows
           language: shell
           before_install:
-              - curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o miniconda.exe
-              - start /wait "" miniconda.exe /S
+              - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
+              - travis_retry start /wait "" miniconda.exe /S
               - conda config --set quiet yes --set always_yes yes --set changeps1 no
               - travis_retry conda update -n base -c defaults conda
               - travis_retry conda update --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,41 +49,20 @@ jobs:
         - os: windows
           language: shell
           before_install: 
-            # - export MINICONDA=$HOME/miniconda
-            # - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
-            # - choco install openssl.light
-            # - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
-            # - echo original PATH $PATH
-            # - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/bin||')
-            # - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin||')
-            # - echo manipulated PATH $PATH
-            # - source $MINICONDA/Scripts/activate
-            # - source $MINICONDA/etc/profile.d/conda.sh
-            # - hash -r
-            # - conda config --set quiet yes --set always_yes yes --set changeps1 no
-            # - travis_retry conda update -n base -c defaults conda
-            # - travis_retry conda update --all
-            # - conda config --set solver libmamba
-
             - export MINICONDA_PATH=$HOME/miniconda
             - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
             - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
             - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
             - choco install openssl.light
-            - echo "folder $MINICONDA_SUB_PATH does not exist"
-            - echo "installing miniconda for windows"
             - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
-            - echo "checking if folder $MINICONDA_SUB_PATH exists"
-            - if [[ -d $MINICONDA_SUB_PATH ]]; then echo "folder $MINICONDA_SUB_PATH exists"; else echo "folder $MINICONDA_SUB_PATH does not exist"; fi
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
+            - python --version
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
-
-            # install via exe
-            # - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
-            # - echo 'downloaded miniconda.exe'
-            # - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda
+            - travis_retry conda update -n base -c defaults conda
+            - travis_retry conda update --all
+            - conda config --set solver libmamba
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
             - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
             - echo "$PATH" | wc -c
-            - echo $WINDIR
+            - echo %WINDIR%
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
             - python --version
@@ -109,7 +109,7 @@ script:
     - travis_retry pip install -v -e ".[testing,docs]"
 
     # test suite
-    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then echo $WINDIR; fi
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then echo %WINDIR%; fi
     - tox -v
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
             - choco install openssl.light
             - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
-            - echo "$PATH" | wc -l
+            - echo "$PATH" | wc -c
             - echo $WINDIR
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
@@ -109,7 +109,7 @@ script:
     - travis_retry pip install -v -e ".[testing,docs]"
 
     # test suite
-    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export WINDIR=%SystemRoot%; fi
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then echo $WINDIR; fi
     - tox -v
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,15 @@ jobs:
     #       language: shell        # 'language: python' is not available on Travis CI macOS
         - os: windows
           language: shell
-
+          before_install:
+              - travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
+              - ./miniconda.exe /InstallationType=JustMe /AddToPath=1 /S /D=$HOME\miniconda
 
 before_install:
     # Python package manager
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe; fi
-    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then ./miniconda.exe; else bash miniconda.sh -b -p $HOME/miniconda; fi
-    - export PATH="$HOME/miniconda/bin:$PATH"; hash -r
+    - if [ "$TRAVIS_OS_NAME" -ne "windows" ]; then bash miniconda.sh -b -p $HOME/miniconda; export PATH="$HOME/miniconda/bin:$PATH"; hash -r; fi
     - conda config --set quiet yes --set always_yes yes --set changeps1 no
     - travis_retry conda update -n base -c defaults conda
     - travis_retry conda update --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,20 @@ jobs:
           language: shell
           before_install:
               - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath:1 /S /D=%UserProfile%\miniconda'"
+              - conda config --set quiet yes --set always_yes yes --set changeps1 no
+              - travis_retry conda update -n base -c defaults conda
+              - travis_retry conda update --all
+              - conda config --set solver libmamba
+              # debugging info
+              - conda info -a
+              - conda list
 
 before_install:
     # Python package manager
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-    - if [ "$TRAVIS_OS_NAME" -ne "windows" ]; then bash miniconda.sh -b -p $HOME/miniconda; export PATH="$HOME/miniconda/bin:$PATH"; hash -r; fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"; hash -r
     - conda config --set quiet yes --set always_yes yes --set changeps1 no
     - travis_retry conda update -n base -c defaults conda
     - travis_retry conda update --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,21 +49,36 @@ jobs:
         - os: windows
           language: shell
           before_install: 
-            - export MINICONDA=$HOME/miniconda
-            - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
+            # - export MINICONDA=$HOME/miniconda
+            # - MINICONDA_WIN=$(cygpath --windows $MINICONDA)
+            # - choco install openssl.light
+            # - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
+            # - echo original PATH $PATH
+            # - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/bin||')
+            # - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin||')
+            # - echo manipulated PATH $PATH
+            # - source $MINICONDA/Scripts/activate
+            # - source $MINICONDA/etc/profile.d/conda.sh
+            # - hash -r
+            # - conda config --set quiet yes --set always_yes yes --set changeps1 no
+            # - travis_retry conda update -n base -c defaults conda
+            # - travis_retry conda update --all
+            # - conda config --set solver libmamba
+
+            - export MINICONDA_PATH=$HOME/miniconda
+            - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
+            - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
+            - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
             - choco install openssl.light
-            - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath=1 /D=MINICONDA_WIN'"
-            - echo original PATH $PATH
-            - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/bin||')
-            - PATH=$(echo "$PATH" | sed -e 's|:/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin||')
-            - echo manipulated PATH $PATH
-            - source $MINICONDA/Scripts/activate
-            - source $MINICONDA/etc/profile.d/conda.sh
+            - echo "folder $MINICONDA_SUB_PATH does not exist"
+            - echo "installing miniconda for windows"
+            - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
+            - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
+            - echo "checking if folder $MINICONDA_SUB_PATH exists"
+            - if [[ -d $MINICONDA_SUB_PATH ]]; then echo "folder $MINICONDA_SUB_PATH exists"; else echo "folder $MINICONDA_SUB_PATH does not exist"; fi
+            - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
-            - travis_retry conda update -n base -c defaults conda
-            - travis_retry conda update --all
-            - conda config --set solver libmamba
 
             # install via exe
             # - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ jobs:
             - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
             - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
             - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
+            - export WINDIR=%SystemRoot%
             - choco install openssl.light
             - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
@@ -62,12 +63,6 @@ jobs:
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all
-          install:
-            # runtime dependencies
-            - travis_retry conda create -n test-env
-            - eval "$(conda shell.bash hook)"
-            - conda activate test-env
-            - travis_retry conda install -c conda-forge python=3.9
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ jobs:
             - choco install openssl.light
             - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
             - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
-            - echo $PATH
-            - export WINDIR=%SystemRoot%
+            - echo "$PATH" | wc -l
+            - echo $WINDIR
             - source $MINICONDA_PATH/etc/profile.d/conda.sh
             - hash -r
             - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
 
     # testing dependencies
     - travis_retry conda install -c conda-forge tox flake8 pylint pytest-xdist pytest-cov codecov
-    - travis_retry conda install -c conda-forge networkx matplotlib cartopy sphinx
+    - travis_retry conda install -c conda-forge networkx cartopy sphinx
     - travis_retry conda update  -c conda-forge --all
 
     # debugging info

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,11 +91,6 @@ after_success: codecov
 # modified jobs: OSX + Windows, newest Python version =========================
 # (inherit only 1st `env.jobs` entry)
 
-addons:
-  homebrew:
-    update: false
-    packages: gnu-sed
-
 jobs:
   fast_finish: true
   include:
@@ -105,6 +100,7 @@ jobs:
       before_install:
         - export ARCH=MacOSX-x86_64 SED=gsed
         - export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
+        - travis_retry brew install gnu-sed
 
     - os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,26 +48,14 @@ jobs:
         # Windows job
         - os: windows
           language: shell
+          env: 
+            - PATH=/c/Python311:/c/Python311/Scripts:$PATH
+            - WINDIR=C:\Windows
           before_install:
-            # - export MINICONDA_PATH=$HOME/miniconda
-            # - export MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`
-            # - export MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts
-            # - export MINICONDA_LIB_BIN_PATH=$MINICONDA_PATH/Library/bin
-            # - choco install openssl.light
-            # - choco install miniconda3 --params="'/JustMe /AddToPath:1 /D:$MINICONDA_PATH_WIN'"
-            # - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$MINICONDA_LIB_BIN_PATH:$PATH"
-            # - source $MINICONDA_PATH/etc/profile.d/conda.sh
-            # - hash -r
-            # - python --version
-            # - conda config --set quiet yes --set always_yes yes --set changeps1 no
-            # - travis_retry conda update -n base -c defaults conda
-            # - travis_retry conda update --all
-
-            - choco install python --version 3.11
+            - choco install python --version 3.11.6
             - python -m pip install --upgrade pip
-          env: PATH=/c/Python311:/c/Python311/Scripts:$PATH
           install:
-            - echo "trying pip install right away"
+            - echo using pip install on windows
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,12 @@ jobs:
         - os: windows
           language: shell
           before_install:
-              - choco install miniconda3 --params="'/InstallationType=JustMe /AddToPath:1 /S /D=%UserProfile%\miniconda'"
+              - travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
+              - start /wait "" miniconda.exe /S /InstallationType=JustMe /AddToPath=1 /D=%UserProfile%\miniconda
               - conda config --set quiet yes --set always_yes yes --set changeps1 no
               - travis_retry conda update -n base -c defaults conda
               - travis_retry conda update --all
               - conda config --set solver libmamba
-              # debugging info
-              - conda info -a
-              - conda list
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,28 @@ version: ~> 1.0
 if: branch = master
 
 # # temporarily skip linux job matrix
-# language: python
-# python:
-#     # https://docs.travis-ci.com/user/languages/python/#python-versions
-#     - "3.8"
-#     - "3.9"
-#     - "3.10"
-#     - "3.11"
-#     - "3.12-dev"
-# matrix:
-#     fast_finish: true
-
-# arch: arm64
-# virt: lxd
-# os: linux
-# dist: focal
-# sudo: false
+language: python
+os:
+    - linux
+    - osx
+python:
+    # https://docs.travis-ci.com/user/languages/python/#python-versions
+    - "3.8"
+    - "3.9"
+    - "3.10"
+    - "3.11"
+    - "3.12-dev"
+matrix:
+    fast_finish: true
 
 jobs:
     include:
+        - os: linux
+          arch: arm64
+          virt: lxd
+          os: linux
+          dist: focal
+          sudo: false
         - os: osx
           osx_image: xcode12.2
           language: shell        # 'language: python' is an error on Travis CI macOS
@@ -66,10 +69,6 @@ before_script:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg; fi
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/nthreads=./{s//nthreads=2/;h}; ${x;/./{x;q0};x;q1}' setup.py; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/-j ./      {s//-j 2/;      h}; ${x;/./{x;q0};x;q1}' setup.cfg; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/-n auto/   {s//-n 2/;      h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i '' '/jobs = ./  {s//jobs = 2/;  h}; ${x;/./{x;q0};x;q1}' pyproject.toml; fi
 
 script:
     # package

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
             - conda config --set quiet yes --set always_yes yes --set changeps1 no
             - travis_retry conda update -n base -c defaults conda
             - travis_retry conda update --all
-            - conda config --set solver libmamba
+            - # conda config --set solver libmamba # libmamba solver is not available somehow
 
 before_install:
     # Python package manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,34 @@ version: ~> 1.0
 # require the branch name to be master
 if: branch = master
 
-language: python
-python:
-    # https://docs.travis-ci.com/user/languages/python/#python-versions
-    - "3.8"
-    - "3.9"
-    - "3.10"
-    - "3.11"
-    - "3.12-dev"
-matrix:
-    fast_finish: true
+# # temporarily skip linux job matrix
+# language: python
+# python:
+#     # https://docs.travis-ci.com/user/languages/python/#python-versions
+#     - "3.8"
+#     - "3.9"
+#     - "3.10"
+#     - "3.11"
+#     - "3.12-dev"
+# matrix:
+#     fast_finish: true
 
-arch: arm64
-virt: lxd
-os: linux
-dist: focal
-sudo: false
+# arch: arm64
+# virt: lxd
+# os: linux
+# dist: focal
+# sudo: false
+
+jobs:
+    include:
+        - os: osx
+          osx_image: xcode12.2
+          language: shell        # 'language: python' is an error on Travis CI macOS
 
 before_install:
     # Python package manager
-    - travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O miniconda.sh; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"; hash -r
     - conda config --set quiet yes --set always_yes yes --set changeps1 no
@@ -39,7 +47,8 @@ install:
     - travis_retry conda create -n test-env
     - eval "$(conda shell.bash hook)"
     - conda activate test-env
-    - travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=${TRAVIS_PYTHON_VERSION%-dev}; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry conda install -c conda-forge python=3.11; fi
     - travis_retry conda install -c conda-forge numpy scipy python-igraph h5netcdf tqdm
     - travis_retry conda update  -c conda-forge --all
 

--- a/README.rst
+++ b/README.rst
@@ -78,10 +78,11 @@ Installation
 Dependencies
 ............
 ``pyunicorn`` is implemented in `Python 3 <https://docs.python.org/3/>`_ and
-`Cython 3 <https://cython.org/>`_, and is tested on *Linux*, *macOS* and
-*Windows*. It relies on the following open source or freely available packages,
-which need to be installed on your machine. For exact dependency information,
-see ``setup.cfg``.
+`Cython 3 <https://cython.org/>`_, and is `tested
+<https://app.travis-ci.com/github/pik-copan/pyunicorn>`_ on *Linux*, *macOS*
+and *Windows*. It relies on the following open source or freely available
+packages, which need to be installed on your machine. For exact dependency
+information, see ``setup.cfg``.
 
 Required at runtime:
   - `numpy <http://www.numpy.org/>`_
@@ -154,7 +155,7 @@ please make sure that all tests pass. The test suite is managed by `tox
 <http://tox.readthedocs.io/>`_ and is configured to use system-wide packages
 when available. Install the test dependencies as follows::
 
-    $> pip install .[testing]
+    $> pip install .[tests]
 
 The test suite can be run from anywhere in the project tree by issuing::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ dev =
     Cython >= 3.0
 docs =
     sphinx >= 7.0
+    matplotlib
 tests =
     tox >= 4.3
     flake8 >= 6.0
@@ -92,12 +93,13 @@ envlist =
     docs
 
 [testenv]
-extras =
-    tests
+skip_install = true
+skipsdist = true
 sitepackages = true
 changedir = {toxinidir}
 setenv =
     PYTHONPATH = {toxinidir}/src
+passenv = WINDIR, LC_ALL
 allowlist_externals =
     flake8
     pylint
@@ -105,24 +107,20 @@ allowlist_externals =
     sphinx-build
 
 [testenv:style]
-skipsdist = true
 commands =
     flake8 src/pyunicorn tests
 
 [testenv:lint]
-skipsdist = true
 commands =
     pylint src/pyunicorn tests
 
 [testenv:test]
-passenv = WINDIR
+extras = tests
 commands =
     pytest --cov
 
 [testenv:docs]
-extras =
-    docs
-passenv = WINDIR
+extras = docs
 commands =
     sphinx-build -j 8 -W -b html -d {envtmpdir}/doctrees docs/source {envtmpdir}/html
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ dev =
     Cython >= 3.0
 docs =
     sphinx >= 7.0
-testing =
+tests =
     tox >= 4.3
     flake8 >= 6.0
     pylint >= 2.17
@@ -93,7 +93,7 @@ envlist =
 
 [testenv]
 extras =
-    testing
+    tests
 sitepackages = true
 changedir = {toxinidir}
 setenv =
@@ -107,7 +107,7 @@ allowlist_externals =
 [testenv:style]
 skipsdist = true
 commands =
-    flake8
+    flake8 src/pyunicorn tests
 
 [testenv:lint]
 skipsdist = true
@@ -115,12 +115,14 @@ commands =
     pylint src/pyunicorn tests
 
 [testenv:test]
+passenv = WINDIR
 commands =
     pytest --cov
 
 [testenv:docs]
 extras =
     docs
+passenv = WINDIR
 commands =
     sphinx-build -j 8 -W -b html -d {envtmpdir}/doctrees docs/source {envtmpdir}/html
 
@@ -128,8 +130,7 @@ commands =
 
 [flake8]
 extend-exclude =
-    .git, .cache, .tox, .ropeproject, build,
-    docs/source/conf.py
+    .git, .cache, .tox, .ropeproject, build, docs/source/conf.py
 extend-ignore =
     E121, E123, E126, E226, E24, E704, E731, F401, F403, F405, F812, F841, W503
 per-file-ignores =


### PR DESCRIPTION
I will have to do this step-wise to see what works, as Travis CI documentation does not really cover our specific case. Will start with the macOS job, add a Windows job after that, and finally add the Linux jobs back again, hopefully not needing too many builds along the way.