### PR TITLE
MAINT: fix `Data.print_data_info()`

### DIFF
--- a/src/pyunicorn/core/data.py
+++ b/src/pyunicorn/core/data.py
@@ -387,7 +387,6 @@ class Data:
         """Print information on the data encapsulated by the Data object."""
         # Open netCDF4 file
         f = Dataset(self.file_name, "r")
-        print("File format:", f.file_format)
         print("Global attributes:")
         for name in f.ncattrs():
             print(name + ":", getattr(f, name))


### PR DESCRIPTION
- remove printing `Dataset.file_format` for `h5netcdf` compatibility
- alternatively introduce strict `netCDF4-python` dependency

A rather bold fix, but probably the easiest one. Could not find an alternative attribute to print instead of `file_format`.

Any objections?