### PR TITLE
Avoid using variable name `I` in C code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ classifiers =
 
 [options]
 install_requires =
-    numpy >= 1.24
+    numpy >= 1.24, < 2.0
     scipy >= 1.10
     igraph >= 0.11
     h5netcdf >= 1.1   ; python_version >= "3.9"

--- a/src/pyunicorn/core/_ext/src_numerics.c
+++ b/src/pyunicorn/core/_ext/src_numerics.c
@@ -118,23 +118,23 @@ double _vertex_current_flow_betweenness_fast(int N, double Is, double It,
     int t=0;
     int s=0;
     int j=0;
-    double I=0;
+    double J=0;
 
     for(t=0;t<N;t++){
         for(s=0; s<t; s++){
-            I = 0.0;
+            J = 0.0;
             if(i == t || i == s){
                 continue;
             }
             else{
                 for(j=0;j<N;j++){
-                    I += admittance[i*N+j]*
+                    J += admittance[i*N+j]*
                     fabs( Is*(R[i*N+s]-R[j*N+s])+
                           It*(R[j*N+t]-R[i*N+t])
                         ) / 2.0;
                 } // for  j
             }
-            VCFB += 2.0*I/(N*(N-1));
+            VCFB += 2.0*J/(N*(N-1));
         } // for s
     } // for t
 
@@ -149,19 +149,19 @@ void _edge_current_flow_betweenness_fast(int N, double Is, double It,
     int j=0;
     int t=0;
     int s=0;
-    double I = 0.0;
+    double J = 0.0;
 
     for(i=0; i<N; i++){
         for(j=0;j<N;j++){
-            I = 0.0;
+            J = 0.0;
             for(t=0;t<N;t++){
                 for(s=0; s<t; s++){
-                    I += admittance[i*N+j]*\
+                    J += admittance[i*N+j]*\
                          fabs(Is*(R[i*N+s]-R[j*N+s])+
                               It*(R[j*N+t]-R[i*N+t]));
                 } //for s
             } // for t
-            ECFB[i*N+j] += (float) (2.* I/(N*(N-1)));
+            ECFB[i*N+j] += (float) (2.* J/(N*(N-1)));
         } // for j
     } // for i
 }

--- a/tests/test_timeseries/test_timeseries.py
+++ b/tests/test_timeseries/test_timeseries.py
@@ -21,7 +21,8 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 
 from pyunicorn.timeseries import CrossRecurrencePlot, \
-    InterSystemRecurrenceNetwork, Surrogates, VisibilityGraph
+    RecurrenceNetwork, InterSystemRecurrenceNetwork, \
+    Surrogates, VisibilityGraph
 from pyunicorn.core.data import Data
 from pyunicorn.core._ext.types import DFIELD
 
@@ -68,6 +69,31 @@ def testCrossRecurrencePlot(thresh, rr, metric: str):
     assert CR1.dtype == CR2.dtype
     assert CR1.dtype == np.int8
 
+
+# -----------------------------------------------------------------------------
+# recurrence_network
+# -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("thresh, rr",
+                         [(.2, None), (None, .2)], ids=str)
+def testRecurrenceNetwork(thresh, rr, metric: str):
+    # create two instances of the same test dataset
+    tdata1 = create_test_data()
+    tdata2 = create_test_data()
+    # create RecurrenceNetwork for both
+    rn1 = RecurrenceNetwork(
+            tdata1, threshold=thresh, recurrence_rate=rr, metric=metric)
+    rn2 = RecurrenceNetwork(
+            tdata2, threshold=thresh, recurrence_rate=rr, metric=metric)
+    # get respective adjacency matrices
+    A1 = rn1.adjacency
+    A2 = rn2.adjacency
+
+    assert np.array_equal(A1, A2)
+    assert A1.shape == A2.shape
+    assert A1.shape == (len(tdata1), len(tdata1))
+    assert A1.dtype == A2.dtype
+    assert A1.dtype == np.int16
 
 # -----------------------------------------------------------------------------
 # inter_system_recurrence_network

--- a/tests/test_timeseries/test_timeseries.py
+++ b/tests/test_timeseries/test_timeseries.py
@@ -95,6 +95,24 @@ def testRecurrenceNetwork(thresh, rr, metric: str):
     assert A1.dtype == A2.dtype
     assert A1.dtype == np.int16
 
+
+def testRecurrenceNetwork_setters():
+    tdata = create_test_data()
+    rn = RecurrenceNetwork(tdata, threshold=.2)
+    # recalculate with different fixed threshold
+    rn.set_fixed_threshold(.3)
+    assert rn.adjacency.shape == (len(tdata), len(tdata))
+    # recalculate with fixed threshold in units of the ts' std
+    rn.set_fixed_threshold_std(.3)
+    assert rn.adjacency.shape == (len(tdata), len(tdata))
+    # recalculate with fixed recurrence rate
+    rn.set_fixed_recurrence_rate(.2)
+    assert rn.adjacency.shape == (len(tdata), len(tdata))
+    # recalculate with fixed local recurrence rate
+    rn.set_fixed_local_recurrence_rate(.2)
+    assert rn.adjacency.shape == (len(tdata), len(tdata))
+
+
 # -----------------------------------------------------------------------------
 # inter_system_recurrence_network
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
as was the case in [`core/_ext/src_numerics.c`](https://github.com/pik-copan/pyunicorn/blob/master/src/pyunicorn/core/_ext/src_numerics.c).

This is because `I` is already used for [complex numbers in the `complex.h` library](https://en.cppreference.com/w/c/numeric/complex/I) (see #225).

Note that the remaining functions contained in that file should eventually be migrated to [`core/_ext/numerics.pyx`](https://github.com/pik-copan/pyunicorn/blob/master/src/pyunicorn/core/_ext/numerics.pyx).

Also, the newly released Numpy 2.0 introduces breaking changes with its C API. Migration should be considered at some point using the provided [giude](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide).

