### PR TITLE
STY/TST: minor style fix and new tests in `timeseries`

### DIFF
--- a/src/pyunicorn/timeseries/joint_recurrence_plot.py
+++ b/src/pyunicorn/timeseries/joint_recurrence_plot.py
@@ -183,8 +183,8 @@ class JointRecurrencePlot(RecurrencePlot):
             #  threshold / recurrence rate
             if np.abs(lag) > x.shape[0]:
                 #  Lag must be smaller than size of recurrence plot
-                raise ValueError("Delay value (lag) must not exceed length of \
-                                 time series!")
+                raise ValueError("Delay value (lag) must not exceed length of "
+                                 "time series!")
             if threshold is not None:
                 #  Calculate the recurrence matrix R using the radius of
                 #  neighborhood threshold
@@ -200,16 +200,16 @@ class JointRecurrencePlot(RecurrencePlot):
                 JointRecurrencePlot.\
                     set_fixed_recurrence_rate(self, recurrence_rate)
             else:
-                raise NameError("Please give either threshold or \
-                                recurrence_rate to construct the joint \
-                                recurrence plot!")
+                raise NameError("Please give either threshold or "
+                                "recurrence_rate to construct the joint "
+                                "recurrence plot!")
 
             #  No treatment of missing values yet!
             self.missing_values = False
 
         else:
-            raise ValueError("Both time series x and y need to have the same \
-                             length!")
+            raise ValueError("Both time series x and y need to have the same "
+                             "length!")
 
     def __str__(self):
         """

--- a/tests/test_timeseries/test_joint_recurrence_plot.py
+++ b/tests/test_timeseries/test_joint_recurrence_plot.py
@@ -36,3 +36,17 @@ def test_recurrence(metric: str, n: int):
     assert all(d.shape == (n, n) for d in dist.values())
     assert np.allclose(dist["x"], dist["y"])
     assert jrp.recurrence_matrix().shape == (n, n)
+
+
+def test_exceptions():
+    ts1 = CouplingAnalysis.test_data()[:10, 0]
+    ts2 = CouplingAnalysis.test_data()[:12, 0]
+    # provoke error for missing thresholding parameter
+    with pytest.raises(NameError):
+        JointRecurrencePlot(ts1, ts1)
+    # provoke error for mismatched timeseries lengths
+    with pytest.raises(ValueError):
+        JointRecurrencePlot(ts1, ts2)
+    # provoke error for given lag value too large
+    with pytest.raises(ValueError):
+        JointRecurrencePlot(ts1, ts1, lag=14)

--- a/tests/test_timeseries/test_timeseries.py
+++ b/tests/test_timeseries/test_timeseries.py
@@ -21,7 +21,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 
 from pyunicorn.timeseries import CrossRecurrencePlot, \
-    RecurrenceNetwork, InterSystemRecurrenceNetwork, \
+    RecurrenceNetwork, JointRecurrenceNetwork, InterSystemRecurrenceNetwork, \
     Surrogates, VisibilityGraph
 from pyunicorn.core.data import Data
 from pyunicorn.core._ext.types import DFIELD
@@ -111,6 +111,26 @@ def testRecurrenceNetwork_setters():
     # recalculate with fixed local recurrence rate
     rn.set_fixed_local_recurrence_rate(.2)
     assert rn.adjacency.shape == (len(tdata), len(tdata))
+
+
+# -----------------------------------------------------------------------------
+# joint_recurrence_network
+# -----------------------------------------------------------------------------
+
+
+def testJointRecurrenceNetwork(metric: str):
+    tdata = create_test_data()
+    x = tdata[:, 0]
+    y = tdata[:, 1]
+    n = len(tdata)
+    jrp = JointRecurrenceNetwork(x, y, threshold=(.1, .1),
+                                 metric=(metric, metric))
+    dist = {}
+    for i in "xy":
+        jrp.embedding = getattr(jrp, f"{i}_embedded")
+        dist[i] = jrp.distance_matrix(metric=metric)
+    assert all(d.shape == (n, n) for d in dist.values())
+    assert jrp.recurrence_matrix().shape == (n, n)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- correct bad linebreaks in exception messages, blame e1fb60b
- test for correct raising of modified exceptions in `JointRecurrencePlot`to make CodeCov happy
- also add basic test for `JointRecurrenceNetwork` for improved coverage, inspired by #72