### PR TITLE
Ensure Numpy 2.0 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ classifiers =
 
 [options]
 install_requires =
-    numpy >= 1.24, < 2.0
+    numpy >= 1.24
     scipy >= 1.10
     igraph >= 0.11
     h5netcdf >= 1.1   ; python_version >= "3.9"

--- a/src/pyunicorn/climate/_ext/numerics.pyx
+++ b/src/pyunicorn/climate/_ext/numerics.pyx
@@ -18,8 +18,8 @@ import numpy as np
 cimport numpy as cnp
 from numpy cimport ndarray
 
-from ...core._ext.types import FIELD, DFIELD
-from ...core._ext.types cimport MASK_t, FIELD_t, DFIELD_t
+from ...core._ext.types import FIELD, INT64TYPE
+from ...core._ext.types cimport MASK_t, FIELD_t, INT64TYPE_t
 
 cdef extern from "src_numerics.c":
     void _mutual_information(
@@ -38,12 +38,12 @@ def mutual_information(
     int n_samples, int N, int n_bins, float scaling, float range_min):
 
     cdef:
-        ndarray[long, ndim=2, mode='c'] symbolic = np.zeros(
-            (N, n_samples), dtype=long)
-        ndarray[long, ndim=2, mode='c'] hist = np.zeros(
-            (N, n_bins), dtype=long)
-        ndarray[long, ndim=2, mode='c'] hist2d = np.zeros(
-            (n_bins, n_bins), dtype=long)
+        ndarray[INT64TYPE_t, ndim=2, mode='c'] symbolic = np.zeros(
+            (N, n_samples), dtype=INT64TYPE)
+        ndarray[INT64TYPE_t, ndim=2, mode='c'] hist = np.zeros(
+            (N, n_bins), dtype=INT64TYPE)
+        ndarray[INT64TYPE_t, ndim=2, mode='c'] hist2d = np.zeros(
+            (n_bins, n_bins), dtype=INT64TYPE)
         ndarray[FIELD_t, ndim=2, mode='c'] mi = np.zeros(
             (N, N), dtype=FIELD)
 


### PR DESCRIPTION
Simply enabling Numpy 2.0 builds for now by reverting commit 4b7fd11bdaec66a9df11f246c942cfbe73988af9 and hoping for the best as all ran fine on my local machine. 

TODO:
- [x] check if some dependency version pins must be tweaked in `setup.py`: not necessary
- [x] eventually pin to numpy>=2.0, drop Python 3.8 Travis build: not necessary
- [x] add Python 3.13 build: not until it will be released