### PR TITLE
MAINT: extend caching and review `Surrogates` API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ jobs = 0
 disable = [
     "duplicate-code", "invalid-name", "fixme",
     "missing-docstring", "no-else-return",
-    "arguments-differ", "no-member", "no-name-in-module"
+    "arguments-differ", "no-name-in-module"
 ]
 
 [tool.pylint.format]

--- a/src/pyunicorn/timeseries/inter_system_recurrence_network.py
+++ b/src/pyunicorn/timeseries/inter_system_recurrence_network.py
@@ -18,6 +18,9 @@ on recurrence plots, including measures of recurrence quantification
 analysis (RQA) and recurrence network analysis.
 """
 
+from typing import Tuple
+from collections.abc import Hashable
+
 # array object and fast numerics
 import numpy as np
 
@@ -211,22 +214,8 @@ class InterSystemRecurrenceNetwork(InteractingNetworks):
     #  Service methods
     #
 
-    def clear_cache(self):
-        """
-        Clean up memory by deleting information that can be recalculated from
-        basic data.
-
-        Extends the clean up methods of the parent classes.
-        """
-        #  Call clean up of RecurrencePlot objects
-        self.rp_x.clear_cache()
-        self.rp_y.clear_cache()
-
-        #  Call clean up of CrossRecurrencePlot object
-        self.crp_xy.clear_cache()
-
-        #  Call clean up of InteractingNetworks
-        InteractingNetworks.clear_cache(self)
+    def __cache_state__(self) -> Tuple[Hashable, ...]:
+        return (self.rp_x, self.rp_x, self.crp_xy,)
 
     #
     #  Methods to handle inter system recurrence networks

--- a/src/pyunicorn/timeseries/joint_recurrence_network.py
+++ b/src/pyunicorn/timeseries/joint_recurrence_network.py
@@ -158,18 +158,6 @@ class JointRecurrenceNetwork(JointRecurrencePlot, Network):
                 f"{JointRecurrencePlot.__str__(self)}\n"
                 f"{Network.__str__(self)}")
 
-    def clear_cache(self):
-        """
-        Clean up memory by deleting information that can be recalculated from
-        basic data.
-
-        Extends the clean up methods of the parent classes.
-        """
-        #  Call clean up of RecurrencePlot
-        JointRecurrencePlot.clear_cache(self)
-        #  Call clean up of Network
-        Network.clear_cache(self)
-
     #
     #  Methods to handle recurrence networks
     #

--- a/src/pyunicorn/timeseries/recurrence_network.py
+++ b/src/pyunicorn/timeseries/recurrence_network.py
@@ -152,18 +152,6 @@ class RecurrenceNetwork(RecurrencePlot, Network):
                 f"{RecurrencePlot.__str__(self)}\n"
                 f"{Network.__str__(self)}")
 
-    def clear_cache(self):
-        """
-        Clean up memory by deleting information that can be recalculated from
-        basic data.
-
-        Extends the clean up methods of the parent classes.
-        """
-        #  Call clean up of RecurrencePlot
-        RecurrencePlot.clear_cache(self)
-        #  Call clean up of Network
-        Network.clear_cache(self)
-
     #
     #  Methods to handle recurrence networks
     #

--- a/tests/test_core/test_cache.py
+++ b/tests/test_core/test_cache.py
@@ -73,6 +73,7 @@ class TestCached:
             r1, o1 = [], []
             for _ in range(m + 1):
                 r1.append(X.foo1(1))
+                # pylint: disable-next=no-member
                 o1.append(cls.Foo.foo1.__wrapped__(X, 1))
             r1.append(X.foo1(1.0))
             assert all(r == r1[0] for r in r1)
@@ -81,6 +82,7 @@ class TestCached:
             r2, o2 = [], []
             for i in range(2 * m):
                 r2.append(X.foo2(*range(i)))
+                # pylint: disable-next=no-member
                 o2.append(cls.Foo.foo2.__wrapped__(X, *range(i)))
             assert (np.diff(r2) == range(2 * m - 1)).all()
             assert all(r == o for r, o in zip(r2, o2))
@@ -88,6 +90,7 @@ class TestCached:
             r3, o3 = [], []
             for i in range(5):
                 r3.append(X.bar())
+                # pylint: disable-next=no-member
                 o3.append(cls.Foo.bar.__wrapped__(X))
             assert all(r and isinstance(r, bool) for r in r3)
             assert all(r == o for r, o in zip(r3, o3))


### PR DESCRIPTION
## Commit message

Extend caching according to 93ab748 to
- `RecurrenceNetwork` and child classes
- `Surrogates`

Review API of `Surrogates` to enable caching and reduce redundancy
- remove unhashable argument `original_data` in surrogate methods, use respective attribute
- make `embedding` a property as in `RecurrencePlot`
- substitute static method `normalize_time_series_array()` with regular method `normalize_original_data()` with same functionality
- __make `recurrence_plot()` a static method__ _(missing in commit message)_
- add attributes `self.N`, `self.n_time`
- adapt tests, implement additional tests

Resolve and re-enable pylint flag `no-member`

## Comment

The changed API of Surrogates should be reviewed. Also, is `Surrogates.recurrence_plot()` intended for, when we have the `RecurrencePlot` class?