### PR TITLE
 CI: introduce `ruff` linter and formatter to replace `pylint` and `flake8`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 
 # Translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
     travis_retry conda install -c conda-forge \
         numpy scipy python-igraph h5netcdf[h5py] tqdm \
         ipython networkx matplotlib cartopy sphinx nbsphinx \
-        tox flake8 pylint pytest-xdist pytest-cov
+        tox ruff pytest-xdist pytest-cov
     conda info -a
     conda list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
 
 script:
   - | # install Python libs via Pip: self (+ dependencies, if on Windows)
-    travis_retry pip install -v -e . --group tests --group docs
+    travis_retry pip install -v -e . --group test --group docs
   - | # run test suite
     tox -v
 

--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ please make sure that all tests pass. The test suite is managed by `tox
 <https://tox.wiki/>`_ and is configured to use system-wide packages
 when available. Install the test dependencies as follows::
 
-    $> pip install --group tests
+    $> pip install --group test
 
 The test suite can be run from anywhere in the project tree by issuing::
 
@@ -176,6 +176,5 @@ To display the defined test environments and target them individually::
 
 To test individual files::
 
-    $> flake8 src/pyunicorn/core/network.py     # style check
-    $> pylint src/pyunicorn/core/network.py     # static code analysis
+    $> ruff check src/pyunicorn/core/network.py # linting and formatting
     $> pytest tests/test_core/test_network.py   # unit tests

--- a/docs/source/examples/tutorials/CoupledClimateNetworks.ipynb
+++ b/docs/source/examples/tutorials/CoupledClimateNetworks.ipynb
@@ -242,7 +242,7 @@
     "#  If the boundaries are equal, the data's full range is selected.\n",
     "#  For this tutorial, we choose a window for latitude and longitude corresponding to North America.\n",
     "WINDOW = {\"time_min\": 0., \"time_max\": 0., \"lat_min\": 45, \"lon_min\": 80,\n",
-    "          \"lat_max\": 60, \"lon_max\": 120} \n",
+    "          \"lat_max\": 60, \"lon_max\": 120}\n",
     "#  Indicate the length of the annual cycle in the data (e.g., 12 for monthly\n",
     "#  data). This is used for calculating climatological anomaly values.\n",
     "TIME_CYCLE = 12"
@@ -258,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "33aead33-118a-4e55-a96a-e69c5f3036ba",
    "metadata": {},
    "outputs": [
@@ -295,14 +295,14 @@
    "source": [
     "# number of total vertical levels in the data file\n",
     "VERTICAL_LEVELS = 17\n",
-    "# loop over all levels to create a `ClimateData` object for each level\n",
+    "# loop over all levels to create a `ClimateData` object for each level vl\n",
     "data = np.array([climate.ClimateData.Load(\n",
     "    file_name=DATA_FILE, observable_name=OBSERVABLE_NAME,\n",
     "    data_source=DATA_SOURCE, file_type=FILE_TYPE,\n",
     "    window=WINDOW, time_cycle=TIME_CYCLE,\n",
     "    #  The `vertical_level` argument indicates the vertical level to be extracted from the data file,\n",
     "    #  and is ignored for horizontal data sets. If `None`, the first level in the data file is chosen.\n",
-    "    vertical_level=l) for l in range(VERTICAL_LEVELS)])"
+    "    vertical_level=vl) for vl in range(VERTICAL_LEVELS)])"
    ]
   },
   {
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8872d035",
    "metadata": {
     "scrolled": true
@@ -562,9 +562,9 @@
     "cross_closeness = []\n",
     "cross_betweenness = []\n",
     "\n",
-    "for l in range(VERTICAL_LEVELS):\n",
-    "    # generate a coupled climate network between the ground level and the level l\n",
-    "    coupled_network = climate.CoupledTsonisClimateNetwork(data[0], data[l], threshold=THRESHOLD)\n",
+    "for vl in range(VERTICAL_LEVELS):\n",
+    "    # generate a coupled climate network between the ground level and the current level vl\n",
+    "    coupled_network = climate.CoupledTsonisClimateNetwork(data[0], data[vl], threshold=THRESHOLD)\n",
     "\n",
     "    # calculate global measures\n",
     "    cross_link_density.append(coupled_network.cross_link_density())\n",
@@ -598,20 +598,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "c1ead3e6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# read out the observable hgt (geopotentential height) and average it for each level\n",
+    "# read out the observable hgt (geopotentential height) and average it for each level vl\n",
     "hgt_averaged = np.array([\n",
-    "    np.round(data[l].observable().flatten().mean() / 1000, 1)\n",
-    "    for l in range(VERTICAL_LEVELS)])"
+    "    np.round(data[vl].observable().flatten().mean() / 1000, 1)\n",
+    "    for vl in range(VERTICAL_LEVELS)])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "6cd75bf5-8c14-4705-920e-8adcbfaeee15",
    "metadata": {},
    "outputs": [],
@@ -623,7 +623,7 @@
     "    Plot the geopotential height over a coupling network measure.\n",
     "    \"\"\"\n",
     "    ax_ = plt if ax is None else ax\n",
-    "    ax_p = lambda p: getattr(*((plt, p) if ax is None else (ax, f\"set_{p}\")))\n",
+    "    ax_p = lambda p: getattr(*((plt, p) if ax is None else (ax, f\"set_{p}\")))  # noqa: E731 (lambda assignment)\n",
     "    ax_.plot(measure, hgt_averaged, 'o', color='blue')\n",
     "    ax_p(\"xlabel\")(r\"${}\".format(xlabel) + xindex + r\"$\")\n",
     "    if set_ylabel:\n",
@@ -800,7 +800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "aac4fd1e-1fae-48c7-9d26-692bf5a7a05c",
    "metadata": {},
    "outputs": [],
@@ -824,12 +824,12 @@
     "    fig, axes = plt.subplots(1, 2, layout=\"constrained\")\n",
     "    fig.suptitle(title)\n",
     "    Z = np.zeros((VERTICAL_LEVELS, len(lat)))\n",
-    "    \n",
+    "\n",
     "    # plot both vertical directions of coupling\n",
     "    for vert in range(2):\n",
     "        # average over lon with same lat\n",
-    "        for l in range(VERTICAL_LEVELS):\n",
-    "            Z[l] = measure[l][vert].reshape(len(lat), len(lon)).mean(axis=1)\n",
+    "        for vl in range(VERTICAL_LEVELS):\n",
+    "            Z[vl] = measure[vl][vert].reshape(len(lat), len(lon)).mean(axis=1)\n",
     "        Z = Z if transform is None else transform(Z)\n",
     "        ax = axes[vert]\n",
     "        pcm = ax.pcolormesh(X, Y, Z)\n",

--- a/docs/source/examples/tutorials/RecurrenceNetworks.ipynb
+++ b/docs/source/examples/tutorials/RecurrenceNetworks.ipynb
@@ -114,7 +114,7 @@
     "    Returns a time series of length T using the logistic map\n",
     "    x_(n+1) = r*x_n(1-x_n)\n",
     "    at parameter r and using the initial condition x0.\n",
-    "    \n",
+    "\n",
     "    INPUT: x0 - Initial condition, 0 <= x0 <= 1\n",
     "            r - Bifurcation parameter, 0 <= r <= 4\n",
     "            T - length of the desired time series\n",
@@ -124,7 +124,7 @@
     "    # spinup\n",
     "    for n in range(spinup):\n",
     "        x0 = r * x0 * (1 - x0)\n",
-    "    \n",
+    "\n",
     "    timeseries = np.zeros(T + 1)\n",
     "    timeseries[0] = x0\n",
     "    for n in range(T):\n",
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4e4391fc",
    "metadata": {},
    "outputs": [
@@ -175,7 +175,7 @@
     "plt.figure(figsize=(14, 4), dpi=80)\n",
     "plt.plot(time_series, \"b\")\n",
     "plt.xlabel(\"$n$\")\n",
-    "plt.ylabel(\"$x_n$\");"
+    "plt.ylabel(\"$x_n$\")"
    ]
   },
   {
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ad52fdac",
    "metadata": {},
    "outputs": [
@@ -224,7 +224,7 @@
     "rp = RecurrencePlot(time_series, metric=METRIC,\n",
     "                    normalize=False, threshold_std=EPS_std)\n",
     "plt.matshow(rp.recurrence_matrix())\n",
-    "plt.xlabel(\"$n$\"); plt.ylabel(\"$n$\");"
+    "plt.xlabel(\"$n$\"); plt.ylabel(\"$n$\")"
    ]
   },
   {
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "72890ded",
    "metadata": {},
    "outputs": [
@@ -339,7 +339,7 @@
     "\n",
     "plt.figure(figsize=(14, 4), dpi=80)\n",
     "plt.plot(C_v, \"r\")\n",
-    "plt.xlabel(\"$n$\"); plt.ylabel(\"$C_v$\");"
+    "plt.xlabel(\"$n$\"); plt.ylabel(\"$C_v$\")"
    ]
   },
   {
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "e5b29970",
    "metadata": {},
    "outputs": [
@@ -467,16 +467,16 @@
     "rp = RecurrencePlot(time_series, metric=METRIC,\n",
     "                    normalize=False, recurrence_rate=RR)\n",
     "plt.matshow(rp.recurrence_matrix())\n",
-    "plt.xlabel(\"$n$\"); plt.ylabel(\"$n$\");\n",
+    "plt.xlabel(\"$n$\"); plt.ylabel(\"$n$\")\n",
     "\n",
     "rn = RecurrenceNetwork(time_series, metric=METRIC,\n",
     "                       normalize=False, recurrence_rate=RR)\n",
-    "# Local measures: \n",
+    "# Local measures:\n",
     "# - Local Clustering Coefficients\n",
     "C_v = rn.local_clustering()\n",
     "plt.figure(figsize=(14, 4), dpi=80)\n",
     "plt.plot(C_v, \"r\")\n",
-    "plt.xlabel(\"$n$\"); plt.ylabel(\"$C_v$\");\n",
+    "plt.xlabel(\"$n$\"); plt.ylabel(\"$C_v$\")\n",
     "\n",
     "# Global measures:\n",
     "# - Global Clustering Coefficient\n",
@@ -546,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "05eb6b57",
    "metadata": {},
    "outputs": [
@@ -567,7 +567,7 @@
     "ax = plt.figure().add_subplot(projection='3d')\n",
     "ax.plot(*lorenz.T, lw=0.5)\n",
     "ax.set_xlabel(\"X Axis\"); ax.set_ylabel(\"Y Axis\"); ax.set_zlabel(\"Z Axis\")\n",
-    "ax.set_title(\"Lorenz Attractor\");"
+    "ax.set_title(\"Lorenz Attractor\")"
    ]
   },
   {
@@ -663,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "12015724",
    "metadata": {},
    "outputs": [
@@ -686,7 +686,7 @@
     "scat_plot = ax.scatter(*lorenz.T, lw=0.5, c=CD_v, s=1, cmap=plt.colormaps[\"jet\"])\n",
     "cb = plt.colorbar(scat_plot, pad=0.2)\n",
     "ax.set_xlabel(\"X\"); ax.set_ylabel(\"Y\"); ax.set_zlabel(\"Z\")\n",
-    "ax.set_title(f\"$CD_v$ for fixed $RR = {RR}$\");"
+    "ax.set_title(f\"$CD_v$ for fixed $RR = {RR}$\")"
    ]
   },
   {
@@ -766,7 +766,7 @@
     }
    ],
    "source": [
-    "lorenz_T = lorenz_rn.transitivity() \n",
+    "lorenz_T = lorenz_rn.transitivity()\n",
     "print(f\"T = {lorenz_T}\")\n",
     "TD = np.log(lorenz_T) / np.log(3/4)\n",
     "print(f\"TD = {TD}\")"
@@ -829,7 +829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "0a009840",
    "metadata": {},
    "outputs": [
@@ -846,10 +846,10 @@
    ],
    "source": [
     "plt.figure(figsize=(14, 4), dpi=80)\n",
-    "plt.plot(rr, TD, label= \"Lorenz attractor (10000 timesteps)\") \n",
+    "plt.plot(rr, TD, label= \"Lorenz attractor (10000 timesteps)\")\n",
     "plt.xlabel('recurrence rate $RR$')\n",
     "plt.ylabel('transitivity dimension $TD$')\n",
-    "plt.legend(loc = \"lower right\");"
+    "plt.legend(loc = \"lower right\")"
    ]
   }
  ],

--- a/docs/source/examples/tutorials/VisibilityGraphs.ipynb
+++ b/docs/source/examples/tutorials/VisibilityGraphs.ipynb
@@ -182,13 +182,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "745b1e50",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import math\n",
-    "\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "from pyunicorn.timeseries import VisibilityGraph"
@@ -470,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scipy.stats import gaussian_kde \n",
+    "from scipy.stats import gaussian_kde\n",
     "gkde_r1 = gaussian_kde(k_r1)\n",
     "gkde_a1 = gaussian_kde(k_a1)"
    ]
@@ -623,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "7051fb29-c0f0-4d8d-b0e2-2a5b8e7bd353",
    "metadata": {},
    "outputs": [
@@ -647,7 +645,7 @@
     "cutoff = 200\n",
     "plt.figure(figsize=(14, 4))\n",
     "plt.plot(time_series[:cutoff])\n",
-    "plt.xlabel(\"$n$\"); plt.ylabel(\"$x_n$\");"
+    "plt.xlabel(\"$n$\"); plt.ylabel(\"$x_n$\")"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,35 +53,36 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "numpy >= 1.24",
-  "scipy >= 1.10",
-  "igraph >= 0.11",
-  "h5netcdf[h5py] >= 1.8",
-  "tqdm >= 4.66",
+  "numpy>=1.24",
+  "scipy>=1.10",
+  "igraph>=0.11",
+  "h5netcdf[h5py]>=1.8",
+  "tqdm>=4.66",
 ]
 
 [dependency-groups]
 dev = [
-  "Cython >= 3.0",
+  "Cython>=3.0",
+  "ipykernel>=7.3.0",
 ]
 test = [
-  "tox >= 4.11",
+  "tox>=4.11",
   "ruff>=0.15.20",
-  "pytest >= 8.0",
-  "pytest-xdist >= 3.5",
-  "pytest-cov >= 4.1",
-  "networkx >= 3.1",
-  "matplotlib >= 3.6",
-  "cartopy >= 0.21",
-  "requests",
-  "psutil",
+  "pytest>=8.0",
+  "pytest-xdist>=3.5",
+  "pytest-cov>=4.1",
+  "networkx>=3.1",
+  "matplotlib>=3.6",
+  "cartopy>=0.21",
+  "requests>=2.32.5",
+  "psutil>=7.1.3",
 ]
 docs = [
-  "sphinx >= 7.0",
-  "nbsphinx >= 0.9.3",
-  "ipython >= 8.4",
-  "pandoc >= 2.3",
-  "matplotlib >= 3.6",
+  "sphinx>=7.0",
+  "nbsphinx>=0.9.3",
+  "ipython>=8.4",
+  "pandoc>=2.3",
+  "matplotlib>=3.6",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,9 @@ dependencies = [
 dev = [
   "Cython >= 3.0",
 ]
-tests = [
+test = [
   "tox >= 4.11",
-  "flake8 >= 7.0",
-  "Flake8-pyproject >= 1.2",
-  "pylint >= 3.0",
+  "ruff>=0.15.20",
   "pytest >= 8.0",
   "pytest-xdist >= 3.5",
   "pytest-cov >= 4.1",
@@ -87,7 +85,7 @@ docs = [
 ]
 
 [tool.uv]
-default-groups = ["dev", "tests", "docs"]
+default-groups = ["dev", "test", "docs"]
 
 [project.urls]
 Homepage = "https://www.pik-potsdam.de/members/donges/software-2/software"
@@ -106,25 +104,19 @@ include = [ "pyunicorn*" ]
 # testing ======================================================================
 
 [tool.tox]
-env_list = ["style", "lint", "test", "docs"]
+env_list = ["lint", "test", "docs"]
 skipsdist = true
 
 [tool.tox.env_run_base]
 sitepackages = true
 set_env = { PYTHONPATH = "{tox_root}/src" }
 pass_env = ["WINDIR", "LC_ALL"]
-allowlist_externals = ["flake8", "pylint", "pytest", "sphinx-build", "pandoc"]
-
-[tool.tox.env.style]
-package = "skip"
-commands = [[
-  "flake8", "-j{env:TOX_JOBS:auto}", "setup.py", "src/pyunicorn", "tests"
-]]
+allowlist_externals = ["ruff", "pytest", "sphinx-build", "pandoc"]
 
 [tool.tox.env.lint]
 package = "skip"
 commands = [[
-  "pylint", "-j", "{env:TOX_JOBS:0}", "setup.py", "src/pyunicorn", "tests"
+  "ruff", "check"
 ]]
 
 [tool.tox.env.test]
@@ -155,44 +147,17 @@ source = ["src/pyunicorn"]
 
 # static analysis ==============================================================
 
-[tool.flake8]
-extend-exclude = [
-  ".git", ".cache", ".tox", ".ropeproject", "build", "docs/source/conf.py"
-]
-per-file-ignores = [
-  "*/__init__.py:F401,F403",
-]
-max-line-length = 100
+[tool.ruff]
 
-[tool.pylint.main]
+# Same as Black.
+line-length = 100
+indent-width = 4
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = []
 ignore = [
-  ".cache", "__pycache__", ".pytest_cache", ".tox", ".venv", ".ropeproject",
-  "build", "mpi.py"
-]
-ignore-patterns = ["navigator", "numerics"]
-persistent = false
-jobs = 0
-
-[tool.pylint."messages control"]
-disable = [
-  "duplicate-code", "invalid-name", "fixme",
-  "missing-docstring", "no-else-return",
-  "arguments-differ", "no-name-in-module"
-]
-
-[tool.pylint.format]
-max-module-lines = 6000
-
-[tool.pylint.refactoring]
-max-nested-blocks = 6
-
-[tool.pylint.design]
-max-args = 12
-max-locals = 95
-max-branches = 50
-max-statements = 230
-max-attributes = 23
-max-public-methods = 120
-
-[tool.pylint.reports]
-output-format = "colorized"
+  "F401"  # "unused-import": resolve these cases
+  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,16 +148,17 @@ source = ["src/pyunicorn"]
 # static analysis ==============================================================
 
 [tool.ruff]
-
-# Same as Black.
 line-length = 100
-indent-width = 4
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = []
+select = ["E4", "E7", "E9", "F", "W"]
 ignore = [
-  "F401"  # "unused-import": resolve these cases
+  "E702",  # "multiple-statements-on-one-line-colon"
   ]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `F401` (unused-import) in all `__init__.py` files
+"__init__.py" = ["F401"]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # for complex systems science: The pyunicorn package"
 
 
-# pylint: disable=import-error
 from platform import system
 import os
 

--- a/src/pyunicorn/__init__.py
+++ b/src/pyunicorn/__init__.py
@@ -30,4 +30,4 @@ timeseries
 
 from .version import __version__
 from .utils import mpi
-from .core import *
+from .core import *  # noqa: F403 (undefined-local-with-import-star)

--- a/src/pyunicorn/climate/climate_data.py
+++ b/src/pyunicorn/climate/climate_data.py
@@ -42,7 +42,6 @@ class ClimateData(Data, Cached):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, observable, grid, time_cycle, anomalies=False,
                  observable_name="", observable_long_name=None, window=None,
                  silence_level=0):
@@ -104,7 +103,6 @@ class ClimateData(Data, Cached):
     #
 
     @classmethod
-    # pylint: disable=too-many-positional-arguments
     def Load(cls, file_name, observable_name, file_type="NetCDF",
              dimension_names=None, window=None, vertical_level=None,
              silence_level=0, time_cycle=None, data_source=None):

--- a/src/pyunicorn/climate/climate_network.py
+++ b/src/pyunicorn/climate/climate_network.py
@@ -41,7 +41,6 @@ class ClimateNetwork(GeoNetwork):
     #  Definitions of internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, grid: GeoGrid, similarity_measure: np.ndarray,
                  threshold=None, link_density=None, non_local=False,
                  directed=False, node_weight_type="surface", silence_level=0):
@@ -146,7 +145,6 @@ class ClimateNetwork(GeoNetwork):
     #  Load and save ClimateNetwork object
     #
 
-    # pylint: disable=keyword-arg-before-vararg
     def save(self, filename, fileformat=None, *args, **kwds):
         """
         Save the ClimateNetwork object to files.
@@ -204,7 +202,6 @@ class ClimateNetwork(GeoNetwork):
             similarity_measure = self.similarity_measure()
             similarity_measure.dump(filename_similarity_measure)
 
-    # pylint: disable=keyword-arg-before-vararg
     @staticmethod
     def Load(filename, fileformat=None, silence_level=0, *args, **kwds):
         """

--- a/src/pyunicorn/climate/coupled_climate_network.py
+++ b/src/pyunicorn/climate/coupled_climate_network.py
@@ -43,7 +43,6 @@ class CoupledClimateNetwork(InteractingNetworks, ClimateNetwork):
     #  Definitions of internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, grid_1, grid_2, similarity_measure, threshold=None,
                  link_density=None, non_local=False, directed=False,
                  node_weight_type="surface", silence_level=0):

--- a/src/pyunicorn/climate/coupled_tsonis.py
+++ b/src/pyunicorn/climate/coupled_tsonis.py
@@ -21,7 +21,6 @@ import numpy as np
 from .coupled_climate_network import CoupledClimateNetwork
 
 
-# pylint: disable=too-many-ancestors
 class CoupledTsonisClimateNetwork(CoupledClimateNetwork):
 
     """
@@ -48,7 +47,6 @@ class CoupledTsonisClimateNetwork(CoupledClimateNetwork):
     #  Definitions of internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data_1, data_2, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface",
                  selected_months=None, silence_level=0):

--- a/src/pyunicorn/climate/havlin.py
+++ b/src/pyunicorn/climate/havlin.py
@@ -50,7 +50,6 @@ class HavlinClimateNetwork(ClimateNetwork):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, max_delay, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface", silence_level=0):
         """

--- a/src/pyunicorn/climate/hilbert.py
+++ b/src/pyunicorn/climate/hilbert.py
@@ -55,7 +55,6 @@ class HilbertClimateNetwork(ClimateNetwork):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, threshold=None, link_density=None,
                  non_local=False, directed=True, node_weight_type="surface",
                  silence_level=0):

--- a/src/pyunicorn/climate/map_plot.py
+++ b/src/pyunicorn/climate/map_plot.py
@@ -34,7 +34,6 @@ from ..core import Grid
 #
 
 
-# pylint: disable=too-few-public-methods
 class MapPlot:
     """
     Encapsulates map plotting functions via Cartopy and Matplotlib.
@@ -53,11 +52,9 @@ class MapPlot:
         #
 
         # Specify Coordinate Refference System for Map Projection
-        # pylint: disable-next=abstract-class-instantiated
         self.projection = ccrs.PlateCarree()
 
         # Specify CRS (where data should be plotted)
-        # pylint: disable-next=abstract-class-instantiated
         self.crs = ccrs.PlateCarree()
 
         # get spatial dims

--- a/src/pyunicorn/climate/mutual_info.py
+++ b/src/pyunicorn/climate/mutual_info.py
@@ -44,7 +44,6 @@ class MutualInfoClimateNetwork(ClimateNetwork):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface", winter_only=True,
                  silence_level=0):

--- a/src/pyunicorn/climate/partial_correlation.py
+++ b/src/pyunicorn/climate/partial_correlation.py
@@ -43,7 +43,6 @@ class PartialCorrelationClimateNetwork(TsonisClimateNetwork):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface", winter_only=True,
                  silence_level=0):

--- a/src/pyunicorn/climate/rainfall.py
+++ b/src/pyunicorn/climate/rainfall.py
@@ -56,7 +56,6 @@ class RainfallClimateNetwork(ClimateNetwork):
     # Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface",
                  event_threshold=(0, 1), scale_fac=37265, offset=10**(-7),

--- a/src/pyunicorn/climate/spearman.py
+++ b/src/pyunicorn/climate/spearman.py
@@ -49,7 +49,6 @@ class SpearmanClimateNetwork(TsonisClimateNetwork):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface", winter_only=True,
                  silence_level=0):

--- a/src/pyunicorn/climate/tsonis.py
+++ b/src/pyunicorn/climate/tsonis.py
@@ -42,7 +42,6 @@ class TsonisClimateNetwork(ClimateNetwork):
     #  Defines internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, data, threshold=None, link_density=None,
                  non_local=False, node_weight_type="surface", winter_only=True,
                  silence_level=0):

--- a/src/pyunicorn/core/data.py
+++ b/src/pyunicorn/core/data.py
@@ -325,7 +325,7 @@ class Data:
         # Get length of raw data time axis
         n_time = res["observable"].shape[0]
         # Reshape observable to comply with the standard shape (time, index)
-        res["observable"].shape = (n_time, -1)
+        res["observable"] = res["observable"].reshape((n_time, -1))
 
         # Get long name of observable
         res["observable_long_name"] = f.variables[observable_name].long_name

--- a/src/pyunicorn/core/data.py
+++ b/src/pyunicorn/core/data.py
@@ -47,7 +47,6 @@ class Data:
     #  Define internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, observable: np.ndarray, grid: GeoGrid,
                  observable_name: str = None, observable_long_name: str = None,
                  window: Optional[dict] = None, silence_level: int = 0):
@@ -130,7 +129,6 @@ class Data:
     #
 
     @classmethod
-    # pylint: disable=too-many-positional-arguments
     def Load(cls, file_name, observable_name, file_type, dimension_names=None,
              window=None, vertical_level=None, silence_level=0):
         """
@@ -234,7 +232,6 @@ class Data:
     #
 
     @classmethod
-    # pylint: disable=too-many-positional-arguments
     def _get_netcdf_data(cls, file_name, file_type, observable_name,
                          dimension_names, vertical_level=None,
                          silence_level=0):
@@ -340,7 +337,6 @@ class Data:
         return res
 
     @classmethod
-    # pylint: disable=too-many-positional-arguments
     def _load_data(cls, file_name, file_type, observable_name,
                    dimension_names, vertical_level=None, silence_level=0):
         """

--- a/src/pyunicorn/core/geo_network.py
+++ b/src/pyunicorn/core/geo_network.py
@@ -38,7 +38,6 @@ class GeoNetwork(SpatialNetwork):
     #  Definitions of internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, grid: GeoGrid, adjacency=None, edge_list=None,
                  directed=False, node_weight_type="surface", silence_level=0):
         """
@@ -119,7 +118,6 @@ class GeoNetwork(SpatialNetwork):
     #  Load and save GeoNetwork object
     #
 
-    # pylint: disable=keyword-arg-before-vararg
     @staticmethod
     def Load(filename, fileformat=None, silence_level=0, *args, **kwds):
         """

--- a/src/pyunicorn/core/interacting_networks.py
+++ b/src/pyunicorn/core/interacting_networks.py
@@ -1136,7 +1136,6 @@ class InteractingNetworks(Network):
         :rtype: 1D array [node index]
         :return: the cross in degree sequence.
         """
-        # pylint: disable=arguments-out-of-order
         if link_attribute is None:
             return np.sum(self.cross_adjacency(node_list2, node_list1), axis=0)
         else:

--- a/src/pyunicorn/core/network.py
+++ b/src/pyunicorn/core/network.py
@@ -137,7 +137,6 @@ class Network(Cached):
     #  Definitions of internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, adjacency=None, n_nodes=None, edge_list=None,
                  directed=False, node_weights=None, silence_level=0):
         """
@@ -516,7 +515,6 @@ class Network(Cached):
     #  Load and save Network object
     #
 
-    # pylint: disable=keyword-arg-before-vararg
     def save(self, filename, fileformat=None, *args, **kwds):
         """
         Save the Network object to a file.
@@ -557,7 +555,6 @@ class Network(Cached):
 
         self.graph.write(f=filename, format=fileformat, *args, **kwds)
 
-    # pylint: disable=keyword-arg-before-vararg
     @staticmethod
     def Load(filename, fileformat=None, silence_level=0, *args, **kwds):
         """
@@ -932,7 +929,6 @@ class Network(Cached):
         return np.array(graph.get_adjacency(type=2).data)
 
     @staticmethod
-    # pylint: disable=too-many-positional-arguments
     def GrowWeights(n_nodes=100, n_initials=1, exponent=1,
                     mode="exp",
                     split_prob=.01,  # for exponential model
@@ -1861,7 +1857,6 @@ class Network(Cached):
         """
         return self.local_clustering().mean()
 
-    # pylint: disable=too-many-positional-arguments
     def _motif_clustering_helper(self, t_func, T, link_attribute=None, nsi=False,
                                  typical_weight=None, ksum=None):
         """
@@ -1883,7 +1878,6 @@ class Network(Cached):
         if nsi:
             nodew = sp.csc_matrix(np.eye(self.N) * self.node_weights)
         if link_attribute is None:
-            # pylint: disable=possibly-used-before-assignment
             A = self.sp_Aplus() * nodew if nsi else self.sp_A
             AT = self.sp_Aplus().T * nodew if nsi else A.T
         else:
@@ -1922,7 +1916,6 @@ class Network(Cached):
         :arg str link_attribute: link attribute (optional)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
-        def t_func(x, xT):  # pylint: disable=unused-argument
             return x * x * x
         T = self.indegree() * self.outdegree() - self.bildegree()
         return self._motif_clustering_helper(t_func, T, link_attribute=link_attribute)
@@ -2034,7 +2027,6 @@ class Network(Cached):
             correction. If None, the uncorrected measure is
             returned. (Default: None)
         """
-        def t_func(x, xT):  # pylint: disable=unused-argument
             return x * x * x
         ink = self.nsi_indegree(typical_weight=typical_weight)
         outk = self.nsi_outdegree(typical_weight=typical_weight)
@@ -3343,7 +3335,6 @@ class Network(Cached):
 
     # parallelized main loop
     @staticmethod
-    # pylint: disable=too-many-positional-arguments
     def _mpi_nsi_arenas_betweenness(
             N, sp_P, this_Aplus, w, this_w, start_i, end_i,
             exclude_neighbors, stopping_mode, this_twinness):

--- a/src/pyunicorn/core/network.py
+++ b/src/pyunicorn/core/network.py
@@ -1916,6 +1916,7 @@ class Network(Cached):
         :arg str link_attribute: link attribute (optional)
         :rtype: 1d numpy array [node] of floats between 0 and 1
         """
+        def t_func(x, xT):
             return x * x * x
         T = self.indegree() * self.outdegree() - self.bildegree()
         return self._motif_clustering_helper(t_func, T, link_attribute=link_attribute)
@@ -2027,6 +2028,7 @@ class Network(Cached):
             correction. If None, the uncorrected measure is
             returned. (Default: None)
         """
+        def t_func(x, xT):
             return x * x * x
         ink = self.nsi_indegree(typical_weight=typical_weight)
         outk = self.nsi_outdegree(typical_weight=typical_weight)

--- a/src/pyunicorn/core/resistive_network.py
+++ b/src/pyunicorn/core/resistive_network.py
@@ -71,7 +71,6 @@ class ResNetwork(GeoNetwork):
 ###############################################################################
 # ##                       MAGIC FUNCTIONS                                 ## #
 ###############################################################################
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, resistances, grid=None, adjacency=None, edge_list=None,
                  directed=False, node_weight_type=None, silence_level=2):
 

--- a/src/pyunicorn/core/spatial_network.py
+++ b/src/pyunicorn/core/spatial_network.py
@@ -43,7 +43,6 @@ class SpatialNetwork(Network):
     #  Definitions of internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, grid: Grid, adjacency=None, edge_list=None,
                  directed=False, silence_level=0):
         """
@@ -81,7 +80,6 @@ class SpatialNetwork(Network):
     #  Load and save GeoNetwork object
     #
 
-    # pylint: disable=keyword-arg-before-vararg
     def save(self, filename, fileformat=None, *args, **kwds):
         """
         Save the SpatialNetwork object to files.
@@ -130,7 +128,6 @@ class SpatialNetwork(Network):
         if filename_grid is not None:
             self.grid.save(filename=filename_grid)
 
-    # pylint: disable=keyword-arg-before-vararg
     @staticmethod
     def Load(filename, fileformat=None, silence_level=0, *args, **kwds):
         """

--- a/src/pyunicorn/funcnet/coupling_analysis.py
+++ b/src/pyunicorn/funcnet/coupling_analysis.py
@@ -221,7 +221,6 @@ class CouplingAnalysis:
         else:
             return None
 
-    # pylint: disable=too-many-positional-arguments
     def mutual_information(self, tau_max=0, estimator='knn',
                            knn=10, bins=6, lag_mode='max'):
         r"""
@@ -391,7 +390,6 @@ class CouplingAnalysis:
                                 numpy.dot(x, x) * numpy.dot(y, y)))
 
                     if lag_mode == 'max':
-                        # pylint: disable=possibly-used-before-assignment
                         if ixy_z > maximum:
                             maximum = ixy_z
                             lag_at_max = tau
@@ -410,7 +408,6 @@ class CouplingAnalysis:
         else:
             return None
 
-    # pylint: disable=too-many-positional-arguments
     def information_transfer(self, tau_max=0, estimator='knn',
                              knn=10, past=1, cond_mode='ity', lag_mode='max'):
         r"""
@@ -587,7 +584,6 @@ class CouplingAnalysis:
                                 numpy.dot(x, x) * numpy.dot(y, y)))
 
                     if lag_mode == 'max':
-                        # pylint: disable=possibly-used-before-assignment
                         if ixy_z > maximum:
                             maximum = ixy_z
                             lag_at_max = tau

--- a/src/pyunicorn/funcnet/coupling_analysis_pure_python.py
+++ b/src/pyunicorn/funcnet/coupling_analysis_pure_python.py
@@ -177,7 +177,6 @@ class CouplingAnalysisPurePython:
         :rtype: 3D numpy array (float) [index, index, index]
         :return: correlation matrix with different lag_mode choices
         """
-        # pylint: disable=possibly-used-before-assignment
 
         if lag_mode not in self.lag_modi:
             raise ValueError('lag_mode must be "all", "sum" or "max".')
@@ -257,7 +256,6 @@ class CouplingAnalysisPurePython:
         ## lag_mode dict
         mode = self.lag_modi[lag_mode]
         """
-        # pylint: disable=used-before-assignment
 
         # lag_mode dict
         mode = self.lag_modi[lag_mode]
@@ -439,7 +437,6 @@ class CouplingAnalysisPurePython:
         :rtype: 3D numpy array (float) [index, index, index]
         :return: correlation matrix with different lag_mode choices
         """
-        # pylint: disable=possibly-used-before-assignment
 
         if lag_mode not in self.lag_modi:
             raise ValueError('lag_mode must be "all", "sum" or "max".')
@@ -541,7 +538,6 @@ class CouplingAnalysisPurePython:
                                   bins=bins, tau_max=tau_max,
                                   lag_mode=lag_mode)
 
-    # pylint: disable=too-many-positional-arguments
     def _calculate_mi(self, array, corr_range, bins, tau_max, lag_mode):
         """
         Returns the mi matrix.
@@ -552,7 +548,6 @@ class CouplingAnalysisPurePython:
         :rtype: 3D numpy array (float) [index, index, index]
         :return: correlation matrix with different lag_mode choices
         """
-        # pylint: disable=used-before-assignment
 
         # lag_mode dict
         mode = self.lag_modi[lag_mode]

--- a/src/pyunicorn/timeseries/cross_recurrence_plot.py
+++ b/src/pyunicorn/timeseries/cross_recurrence_plot.py
@@ -119,8 +119,8 @@ class CrossRecurrencePlot(RecurrencePlot):
         """The time series y."""
 
         #  Reshape time series
-        self.x.shape = (self.x.shape[0], -1)
-        self.y.shape = (self.y.shape[0], -1)
+        self.x = self.x.reshape((self.x.shape[0], -1))
+        self.y = self.y.reshape((self.y.shape[0], -1))
 
         #  Normalize time series
         if normalize:

--- a/src/pyunicorn/timeseries/cross_recurrence_plot.py
+++ b/src/pyunicorn/timeseries/cross_recurrence_plot.py
@@ -61,7 +61,6 @@ class CrossRecurrencePlot(RecurrencePlot):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, x, y, metric="supremum", normalize=False,
                  sparse_rqa=False, silence_level=0, **kwds):
         """

--- a/src/pyunicorn/timeseries/inter_system_recurrence_network.py
+++ b/src/pyunicorn/timeseries/inter_system_recurrence_network.py
@@ -67,7 +67,6 @@ class InterSystemRecurrenceNetwork(InteractingNetworks):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, x, y, metric="supremum", normalize=False,
                  silence_level=0, **kwds):
         """

--- a/src/pyunicorn/timeseries/inter_system_recurrence_network.py
+++ b/src/pyunicorn/timeseries/inter_system_recurrence_network.py
@@ -126,8 +126,8 @@ class InterSystemRecurrenceNetwork(InteractingNetworks):
         """The time series y."""
 
         #  Reshape time series
-        self.x.shape = (self.x.shape[0], -1)
-        self.y.shape = (self.y.shape[0], -1)
+        self.x = self.x.reshape((self.x.shape[0], -1))
+        self.y = self.y.reshape((self.y.shape[0], -1))
 
         #  Get embedding dimension and delay from **kwds
         dim = kwds.get("dim")

--- a/src/pyunicorn/timeseries/joint_recurrence_network.py
+++ b/src/pyunicorn/timeseries/joint_recurrence_network.py
@@ -68,7 +68,6 @@ class JointRecurrenceNetwork(JointRecurrencePlot, Network):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, x, y, metric=("supremum", "supremum"),
                  normalize=False, lag=0, silence_level=0, **kwds):
         """

--- a/src/pyunicorn/timeseries/joint_recurrence_plot.py
+++ b/src/pyunicorn/timeseries/joint_recurrence_plot.py
@@ -145,8 +145,8 @@ class JointRecurrencePlot(RecurrencePlot):
             """The time series y."""
 
             #  Reshape time series
-            self.x.shape = (self.x.shape[0], -1)
-            self.y.shape = (self.y.shape[0], -1)
+            self.x = self.x.reshape((self.x.shape[0], -1))
+            self.y = self.y.reshape((self.y.shape[0], -1))
 
             #  Normalize time series
             if normalize:

--- a/src/pyunicorn/timeseries/joint_recurrence_plot.py
+++ b/src/pyunicorn/timeseries/joint_recurrence_plot.py
@@ -64,7 +64,6 @@ class JointRecurrencePlot(RecurrencePlot):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, x, y, metric=("supremum", "supremum"),
                  normalize=False, lag=0, silence_level=0, **kwds):
         """

--- a/src/pyunicorn/timeseries/recurrence_network.py
+++ b/src/pyunicorn/timeseries/recurrence_network.py
@@ -56,7 +56,6 @@ class RecurrenceNetwork(RecurrencePlot, Network):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, time_series, metric="supremum", normalize=False,
                  missing_values=False, silence_level=0, **kwds):
         """

--- a/src/pyunicorn/timeseries/recurrence_plot.py
+++ b/src/pyunicorn/timeseries/recurrence_plot.py
@@ -145,7 +145,7 @@ class RecurrencePlot(Cached):
         """The time series from which the recurrence plot is constructed."""
 
         #  Reshape time series
-        self.time_series.shape = (self.time_series.shape[0], -1)
+        self.time_series = self.time_series.reshape((self.time_series.shape[0], -1))
 
         #  Store type of metric
         self._known_metrics = ("manhattan", "euclidean", "supremum")

--- a/src/pyunicorn/timeseries/recurrence_plot.py
+++ b/src/pyunicorn/timeseries/recurrence_plot.py
@@ -78,7 +78,6 @@ class RecurrencePlot(Cached):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, time_series: NDArray, metric: str = "supremum",
                  normalize: bool = False, missing_values: bool = False,
                  sparse_rqa: bool = False, silence_level: int = 0,

--- a/src/pyunicorn/timeseries/surrogates.py
+++ b/src/pyunicorn/timeseries/surrogates.py
@@ -638,7 +638,6 @@ class Surrogates(Cached):
 
         return (hist, lbb)
 
-    # pylint: disable=too-many-positional-arguments
     def test_threshold_significance(self, surrogate_function, test_function,
                                     realizations=1, n_bins=100,
                                     interval=(-1, 1)):

--- a/src/pyunicorn/timeseries/visibility_graph.py
+++ b/src/pyunicorn/timeseries/visibility_graph.py
@@ -46,7 +46,6 @@ class VisibilityGraph(InteractingNetworks):
     #  Internal methods
     #
 
-    # pylint: disable=too-many-positional-arguments
     def __init__(self, time_series, timings=None, missing_values=False,
                  horizontal=False, silence_level=0):
         """

--- a/tests/test_climate/test_map_plot.py
+++ b/tests/test_climate/test_map_plot.py
@@ -24,7 +24,6 @@ from pyunicorn.climate.map_plot import MapPlot
 matplotlib.use('Agg')
 
 
-# pylint: disable=too-few-public-methods
 class TestMapPlot:
     """
     Simple tests for the `MapPlot` class.

--- a/tests/test_core/test_cache.py
+++ b/tests/test_core/test_cache.py
@@ -54,7 +54,6 @@ def check_single_sref(referent: object, obj: object, attr: str):
             assert r is obj
 
 
-# pylint: disable=no-member,disallowed-name
 class TestCached:
 
     # increase for testing purposes

--- a/tests/test_eventseries/test_event_series.py
+++ b/tests/test_eventseries/test_event_series.py
@@ -721,7 +721,6 @@ def test_eca_pairwise_symmetric_nonuniform():
 def test_joblib_parallel_equivalence():
     """If joblib is available, n_jobs>1 must produce bit-for-bit identical
     matrices to n_jobs=1 for both the blocked-dense and sparse kernels."""
-    # pylint: disable=protected-access
     pytest.importorskip("joblib")
     eventmatrix = _make_binary_matrix(150, 4, p=0.2, seed=7)
 


### PR DESCRIPTION
- removed `flake8` and `pylint` dependencies from `pyproject.toml`, added `ruff`
- replaced and adapted respective settings, including `tox` configuration
- adapted `travis.yml`
- removed all `# pylint: ignore=*` statements in files


yet to do:
- [x] update tox instructions in `README.rst`
- [x] review [`ruff` configuration](https://docs.astral.sh/ruff/configuration/), possibly enabling further codes that are not enabled by default, using the `select` key
- [x] resolve "F401: unused-import" in `__init__`-files: added per-file-ignore

Also note that `ruff` is not a drop-in replacement for `pylint`. In this regard:
- [x] open issue to think about introducing a [type checker alongside ruff](https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-mypy-or-pyright-or-pyre), as already discussed some time ago